### PR TITLE
Refactored Parameter Validation and Unified TiledDataset Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 notebooks/models
 results/
 logs.txt
+test_params.yaml
 
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -1,170 +1,25 @@
-# Makefile for testing main.py
-
-# Load environment variables from .env file
-include .env
-export $(shell sed 's/=.*//' .env)
-
-# Define variables
-
-MASK_IDX = "[10, 201, 222, 493]"
-SHIFT = 2
-SAVE_PATH = results/models
-UID = uid0001
-
-MSDNET_PARAMETERS_1 = '{"network": "MSDNet", \
-			   "num_classes": 3, \
-			   "num_epochs": 3, \
-			   "optimizer": "Adam", \
-			   "criterion": "CrossEntropyLoss", \
-			   "learning_rate": 0.1, \
-			   "activation": "ReLU", \
-			   "normalization": "BatchNorm2d", \
-			   "convolution": "Conv2d", \
-			   "msdnet_parameters": { \
-			   		"layer_width": 1, \
-			   		"num_layers": 3, \
-			   		"custom_dilation": false, \
-			   		"max_dilation": 5 \
-			   		}, \
-			   "dataloaders": { \
-			    	"shuffle_train": true, \
-			    	"batch_size_train": 1, \
-			    	"shuffle_val": true, \
-			   		"batch_size_val": 1, \
-			   		"shuffle_inference": false, \
-			   		"batch_size_inference": 1, \
-			   		"val_pct": 0.2 \
-			   		} \
-			  }'
-
-MSDNET_PARAMETERS_2 = '{"network": "MSDNet", \
-			   "num_classes": 3, \
-			   "num_epochs": 3, \
-			   "optimizer": "Adam", \
-			   "criterion": "CrossEntropyLoss", \
-			   "learning_rate": 0.1, \
-			   "activation": "ReLU", \
-			   "normalization": "BatchNorm2d", \
-			   "convolution": "Conv2d", \
-			   "msdnet_parameters": { \
-			   		"layer_width": 1, \
-			   		"num_layers": 3, \
-			   		"custom_dilation": true, \
-			   		"dilation_array": [1,2,4] \
-			   		}, \
-			   "dataloaders": { \
-			    	"shuffle_train": true, \
-			    	"batch_size_train": 1, \
-			    	"shuffle_val": true, \
-			   		"batch_size_val": 1, \
-			   		"shuffle_inference": false, \
-			   		"batch_size_inference": 1, \
-			   		"val_pct": 0.2 \
-			   		} \
-			  }'
-
-TUNET_PARAMETERS = '{"network": "TUNet", \
-			   "num_classes": 3, \
-			   "num_epochs": 3, \
-			   "optimizer": "Adam", \
-			   "criterion": "CrossEntropyLoss", \
-			   "learning_rate": 0.1, \
-			   "activation": "ReLU", \
-			   "normalization": "BatchNorm2d", \
-			   "convolution": "Conv2d", \
-			   "tunet_parameters": { \
-			   		"depth": 4, \
-			   		"base_channels": 8, \
-			   		"growth_rate": 2, \
-			   		"hidden_rate": 1 \
-			   		}, \
-			   "dataloaders": { \
-			    	"shuffle_train": true, \
-			    	"batch_size_train": 1, \
-			    	"shuffle_val": true, \
-			   		"batch_size_val": 1, \
-			   		"shuffle_inference": false, \
-			   		"batch_size_inference": 1, \
-			   		"val_pct": 0.2 \
-			   		} \
-			  }'
-
-TUNET3PLUS_PARAMETERS = '{"network": "TUNet3+", \
-			   "num_classes": 3, \
-			   "num_epochs": 3, \
-			   "optimizer": "Adam", \
-			   "criterion": "CrossEntropyLoss", \
-			   "learning_rate": 0.1, \
-			   "activation": "ReLU", \
-			   "normalization": "BatchNorm2d", \
-			   "convolution": "Conv2d", \
-			   "tunet3plus_parameters": { \
-			   		"depth": 4, \
-			   		"base_channels": 8, \
-			   		"growth_rate": 2, \
-			   		"hidden_rate": 1, \
-					"carryover_channels": 8 \
-			   		}, \
-			   "dataloaders": { \
-			    	"shuffle_train": true, \
-			    	"batch_size_train": 1, \
-			    	"shuffle_val": true, \
-			   		"batch_size_val": 1, \
-			   		"shuffle_inference": false, \
-			   		"batch_size_inference": 1, \
-			   		"val_pct": 0.2 \
-			   		} \
-			  }'
-
-# Define the default target
-#.PHONY: 
-
 # =================Training Commands==================================== #
 train_msdnet_maxdil:
-	python src/train.py $(DATA_TILED_URI) $(MASK_TILED_URI) \
-                   	   	$(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) \
-                       	$(MASK_IDX) $(SHIFT) $(SAVE_PATH) $(UID) \
-                       	$(MSDNET_PARAMETERS_1)
+	python src/train.py example_yamls/example_msdnet_maxdil.yaml
 
 train_msdnet_customdil:
-	python src/train.py $(DATA_TILED_URI) $(MASK_TILED_URI) \
-                   	   	$(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) \
-                       	$(MASK_IDX) $(SHIFT) $(SAVE_PATH) $(UID) \
-                       	$(MSDNET_PARAMETERS_2)
+	python src/train.py example_yamls/example_msdnet_customdil.yaml
 
 train_tunet:
-	python src/train.py $(DATA_TILED_URI) $(MASK_TILED_URI) \
-                   	   	$(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) \
-                       	$(MASK_IDX) $(SHIFT) $(SAVE_PATH) $(UID) \
-                       	$(TUNET_PARAMETERS)
+	python src/train.py example_yamls/example_tunet.yaml
 
 train_tunet3plus:
-	python src/train.py $(DATA_TILED_URI) $(MASK_TILED_URI) \
-                   	   	$(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) \
-                       	$(MASK_IDX) $(SHIFT) $(SAVE_PATH) $(UID) \
-                       	$(TUNET3PLUS_PARAMETERS)
+	python src/train.py example_yamls/example_tunet3plus.yaml
 
 # =================Inferening Commands==================================== #
 segment_msdnet_maxdil:
-	python src/segment.py $(DATA_TILED_URI) $(MASK_TILED_URI) $(SEG_TILED_URI) \
-                   	   	  $(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) $(SEG_TILED_API_KEY) \
-                       	  $(MASK_IDX) $(SAVE_PATH) $(UID) \
-                          $(MSDNET_PARAMETERS_1)
+	python src/segment.py example_yamls/example_msdnet_maxdil.yaml
 
 segment_msdnet_customdil:
-	python src/segment.py $(DATA_TILED_URI) $(MASK_TILED_URI) $(SEG_TILED_URI) \
-                   	   	  $(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) $(SEG_TILED_API_KEY) \
-                       	  $(MASK_IDX) $(SAVE_PATH) $(UID) \
-                          $(MSDNET_PARAMETERS_2)
+	python src/segment.py example_yamls/example_msdnet_customdil.yaml
 
 segment_tunet:
-	python src/segment.py $(DATA_TILED_URI) $(MASK_TILED_URI) $(SEG_TILED_URI) \
-                   	   	  $(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) $(SEG_TILED_API_KEY) \
-                       	  $(MASK_IDX) $(SAVE_PATH) $(UID) \
-                          $(TUNET_PARAMETERS)
+	python src/segment.py example_yamls/example_tunet.yaml
 
 segment_tunet3plus:
-	python src/segment.py $(DATA_TILED_URI) $(MASK_TILED_URI) $(SEG_TILED_URI) \
-                   	   	  $(DATA_TILED_API_KEY) $(MASK_TILED_API_KEY) $(SEG_TILED_API_KEY) \
-                       	  $(MASK_IDX) $(SAVE_PATH) $(UID) \
-                       	  $(TUNET3PLUS_PARAMETERS)
+	python src/segment.py example_yamls/example_tunet3plus.yaml

--- a/example_parameters.yaml
+++ b/example_parameters.yaml
@@ -1,0 +1,39 @@
+# Example for parameters to excecute
+
+# I/O
+data_tiled_uri: https://foo/bar
+data_tiled_api_key: <secret>
+mask_tiled_uri: https://foo/mask
+mask_tiled_api_key: <another-secret>
+seg_tiled_uri: http://0.0.0.0:8888
+seg_tiled_api_key: <yet-another-one>
+
+mask_idx: [10, 201, 222, 493]
+shift: 2
+save_path: results/models
+uid: uid0001
+
+model_parameters:
+  network: "MSDNet"
+  num_classes: 3
+  num_epochs: 3
+  optimizer: "Adam"
+  criterion: "CrossEntropyLoss"
+  weights: null
+  learning_rate: 0.1
+  activation: "ReLU"
+  normalization: "BatchNorm2d"
+  convolution: "Conv2d"
+
+  shuffle_train: True
+  batch_size_train: 1
+  shuffle_val: True
+  batch_size_val: 1
+  shuffle_inference: False
+  batch_size_inference: 1
+  val_pct: 0.2
+
+  layer_width: 1
+  num_layers: 3
+  custom_dilation: False
+  max_dilation: 5

--- a/example_yamls/example_msdnet_customdil.yaml
+++ b/example_yamls/example_msdnet_customdil.yaml
@@ -1,0 +1,39 @@
+# Example for parameters to excecute
+
+# I/O
+data_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/rec20190524_085542_clay_testZMQ_8bit/20190524_085542_clay_testZMQ_
+data_tiled_api_key: <secret>
+mask_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/seg-partial-rec20190524_085542_clay_testZMQ_8bit/seg-partial-20190524_085542_clay_testZMQ_
+mask_tiled_api_key: <secret>
+seg_tiled_uri: http://0.0.0.0:8888
+seg_tiled_api_key: <secret>
+
+mask_idx: [10, 201, 222, 493]
+shift: 2
+save_path: results/models
+uid: uid0014
+
+model_parameters:
+  network: "MSDNet"
+  num_classes: 3
+  num_epochs: 3
+  optimizer: "Adam"
+  criterion: "CrossEntropyLoss"
+  weights: null
+  learning_rate: 0.1
+  activation: "ReLU"
+  normalization: "BatchNorm2d"
+  convolution: "Conv2d"
+
+  shuffle_train: True
+  batch_size_train: 1
+  shuffle_val: True
+  batch_size_val: 1
+  shuffle_inference: False
+  batch_size_inference: 1
+  val_pct: 0.2
+
+  layer_width: 1
+  num_layers: 3
+  custom_dilation: True
+  dilation_array: [1, 2, 4]

--- a/example_yamls/example_msdnet_maxdil.yaml
+++ b/example_yamls/example_msdnet_maxdil.yaml
@@ -1,0 +1,39 @@
+# Example for parameters to excecute
+
+# I/O
+data_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/rec20190524_085542_clay_testZMQ_8bit/20190524_085542_clay_testZMQ_
+data_tiled_api_key: <secret>
+mask_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/seg-partial-rec20190524_085542_clay_testZMQ_8bit/seg-partial-20190524_085542_clay_testZMQ_
+mask_tiled_api_key: <secret>
+seg_tiled_uri: http://0.0.0.0:8888
+seg_tiled_api_key: <secret>
+
+mask_idx: [10, 201, 222, 493]
+shift: 2
+save_path: results/models
+uid: uid0013
+
+model_parameters:
+  network: "MSDNet"
+  num_classes: 3
+  num_epochs: 3
+  optimizer: "Adam"
+  criterion: "CrossEntropyLoss"
+  weights: null
+  learning_rate: 0.1
+  activation: "ReLU"
+  normalization: "BatchNorm2d"
+  convolution: "Conv2d"
+
+  shuffle_train: True
+  batch_size_train: 1
+  shuffle_val: True
+  batch_size_val: 1
+  shuffle_inference: False
+  batch_size_inference: 1
+  val_pct: 0.2
+
+  layer_width: 1
+  num_layers: 3
+  custom_dilation: False
+  max_dilation: 5

--- a/example_yamls/example_tunet.yaml
+++ b/example_yamls/example_tunet.yaml
@@ -1,20 +1,20 @@
 # Example for parameters to excecute
 
 # I/O
-data_tiled_uri: https://foo/bar
+data_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/rec20190524_085542_clay_testZMQ_8bit/20190524_085542_clay_testZMQ_
 data_tiled_api_key: <secret>
-mask_tiled_uri: https://foo/mask
-mask_tiled_api_key: <another-secret>
+mask_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/seg-partial-rec20190524_085542_clay_testZMQ_8bit/seg-partial-20190524_085542_clay_testZMQ_
+mask_tiled_api_key: <secret>
 seg_tiled_uri: http://0.0.0.0:8888
-seg_tiled_api_key: <yet-another-one>
+seg_tiled_api_key: <secret>
 
 mask_idx: [10, 201, 222, 493]
 shift: 2
 save_path: results/models
-uid: uid0001
+uid: uid0015
 
 model_parameters:
-  network: "MSDNet"
+  network: "TUNet"
   num_classes: 3
   num_epochs: 3
   optimizer: "Adam"
@@ -33,7 +33,7 @@ model_parameters:
   batch_size_inference: 1
   val_pct: 0.2
 
-  layer_width: 1
-  num_layers: 3
-  custom_dilation: False
-  max_dilation: 5
+  depth: 4
+  base_channels: 8
+  growth_rate: 2
+  hidden_rate: 1

--- a/example_yamls/example_tunet3plus.yaml
+++ b/example_yamls/example_tunet3plus.yaml
@@ -1,0 +1,40 @@
+# Example for parameters to excecute
+
+# I/O
+data_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/rec20190524_085542_clay_testZMQ_8bit/20190524_085542_clay_testZMQ_
+data_tiled_api_key: <secret>
+mask_tiled_uri: https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/seg-partial-rec20190524_085542_clay_testZMQ_8bit/seg-partial-20190524_085542_clay_testZMQ_
+mask_tiled_api_key: <secret>
+seg_tiled_uri: http://0.0.0.0:8888
+seg_tiled_api_key: <secret>
+
+mask_idx: [10, 201, 222, 493]
+shift: 2
+save_path: results/models
+uid: uid0016
+
+model_parameters:
+  network: "TUNet3+"
+  num_classes: 3
+  num_epochs: 3
+  optimizer: "Adam"
+  criterion: "CrossEntropyLoss"
+  weights: null
+  learning_rate: 0.1
+  activation: "ReLU"
+  normalization: "BatchNorm2d"
+  convolution: "Conv2d"
+
+  shuffle_train: True
+  batch_size_train: 1
+  shuffle_val: True
+  batch_size_val: 1
+  shuffle_inference: False
+  batch_size_inference: 1
+  val_pct: 0.2
+
+  depth: 4
+  base_channels: 8
+  growth_rate: 2
+  hidden_rate: 1
+  carryover_channels: 8

--- a/src/network.py
+++ b/src/network.py
@@ -104,20 +104,20 @@ def build_network(
     out_channels = num_classes
 
     if parameters.activation is not None:
-        activation = getattr(nn, parameters.activation.value)
+        activation = getattr(nn, parameters.activation)
         activation = activation()
 
     if parameters.normalization is not None:
-        normalization = getattr(nn, parameters.normalization.value)
+        normalization = getattr(nn, parameters.normalization)
 
     if parameters.convolution is not None:
-        convolution = getattr(nn, parameters.convolution.value)   
+        convolution = getattr(nn, parameters.convolution)   
 
     if network == 'MSDNet':
         network = build_msdnet(
             in_channels,
             out_channels,
-            parameters.msdnet_parameters,
+            parameters,
             activation,
             normalization,
             convolution,
@@ -128,7 +128,7 @@ def build_network(
             in_channels,
             out_channels,
             image_shape,
-            parameters.tunet_parameters,
+            parameters,
             activation,
             normalization,
             )
@@ -138,7 +138,7 @@ def build_network(
             in_channels,
             out_channels,
             image_shape,
-            parameters.tunet3plus_parameters,
+            parameters,
             activation,
             normalization,
             )

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -1,124 +1,51 @@
-from enum import Enum
 from pydantic import BaseModel, Field
 from typing import Optional, List
-import torch.nn as nn
 
-
-class DLSIANetwork(str, Enum):
-    msdnet = 'MSDNet'
-    tunet = 'TUNet'
-    tunet3plus = 'TUNet3+'
-
-
-class Optimizer(str, Enum):
-    adadelta = "Adadelta"
-    adagrad = "Adagrad"
-    adam = "Adam"
-    adamw = "AdamW"
-    sparseadam = "SparseAdam"
-    adamax = "Adamax"
-    asgd = "ASGD"
-    lbfgs = "LBFGS"
-    rmsprop = "RMSprop"
-    rprop = "Rprop"
-    sgd = "SGD"
-
-
-class Criterion(str, Enum):
-    l1loss = "L1Loss" 
-    mseloss = "MSELoss" 
-    crossentropyloss = "CrossEntropyLoss"
-    ctcloss = "CTCLoss"
-    poissonnllloss = "PoissonNLLLoss"
-    gaussiannllloss = "GaussianNLLLoss"
-    kldivloss = "KLDivLoss"
-    bceloss = "BCELoss"
-    bcewithlogitsloss = "BCEWithLogitsLoss"
-    marginrankingloss = "MarginRankingLoss"
-    hingeembeddingloss = "HingeEnbeddingLoss"
-    multilabelmarginloss = "MultiLabelMarginLoss"
-    huberloss = "HuberLoss"
-    smoothl1loss = "SmoothL1Loss"
-    softmarginloss = "SoftMarginLoss"
-    multilabelsoftmarginloss = "MutiLabelSoftMarginLoss"
-    cosineembeddingloss = "CosineEmbeddingLoss"
-    multimarginloss = "MultiMarginLoss"
-    tripletmarginloss = "TripletMarginLoss"
-    tripletmarginwithdistanceloss = "TripletMarginWithDistanceLoss"
-
-
-class Activation(str, Enum):
-    relu = "ReLU"
-    sigmoid = "Sigmoid"
-    tanh = "Tanh"
-    softmax = "Softmax"
-
-
-class Normalization(str, Enum):
-    batchnorm2d = "BatchNorm2d"
-    batchnorm3d = "BatchNorm3d"
-
-
-class Convolution(str, Enum):
-    conv2d = "Conv2d"
-    conv3d = "Conv3d"
-
-
-class MSDNetParameters(BaseModel):
-    layer_width: Optional[int] = Field(1, description="layer width of MSDNet")    
-    num_layers: Optional[int] = Field(None, description="number of layers for MSDNet")
-    custom_dilation: Optional[bool] = Field(None, description="whether to customize dilation for MSDNet")
-    max_dilation: Optional[int] = Field(None, description="maximum dilation for MSDNet")
-    dilation_array: Optional[List[int]] = Field(None, description="customized dilation array for MSDNet")
+#===========================================General Parameters===========================================#
+class TrainingParameters(BaseModel):
+    network: str = Field(description="type of dlsia network used")
+    num_classes: int = Field(description="number of classes as output channel")
+    num_epochs: int = Field(default=10, description="number of epochs")
+    optimizer: str = Field(default="Adam", description="optimizer used for training")
+    criterion: str = Field(default="CrossEntropyLoss", description="criterion for loss")
+    weights: Optional[str] = Field(default=None, description="weights per class for imbalanced labeling")
+    learning_rate: float = Field(default=1e-2, description='learning rate')
     
+    activation: Optional[str] = Field(default="ReLU", description="activation function used in network")
+    normalization: Optional[str] = Field(default="BatchNorm2d", description="normalization used between layers")
+    convolution: Optional[str] = Field(default="Conv2d", description="convolution used in network")
 
-class TUNetParameters(BaseModel):    
-    depth: Optional[int] = Field(None, description='the depth of the UNet')
-    base_channels: Optional[int] = Field(None, description='the number of initial channels for UNet')
-    growth_rate: Optional[int] = Field(None, description='multiplicative growth factor of number of '\
-                                       'channels per layer of depth for UNet')
-    hidden_rate: Optional[int] = Field(None, description='multiplicative growth factor of channels within'\
-                                       ' each layer for UNet')
+    # Below are Data Loader related parameters
+    shuffle_train: Optional[bool] = Field(default=True, description="whether to shuffle data in train set")
+    batch_size_train: Optional[int] = Field(default=1, description="batch size of train set")
 
-class TUNet3PlusParameters(BaseModel):    
-    depth: Optional[int] = Field(None, description='the depth of the UNet3+')
-    base_channels: Optional[int] = Field(None, description='the number of initial channels for UNet3+')
-    growth_rate: Optional[int] = Field(None, description='multiplicative growth factor of number of '\
-                                       'channels per layer of depth for UNet3+')
-    hidden_rate: Optional[int] = Field(None, description='multiplicative growth factor of channels within'\
-                                       ' each layer for UNet3+')
-    carryover_channels: Optional[int] = Field(None, description='the number of channels in each skip '\
-                                              'connection for UNet3+')
- 
+    shuffle_val: Optional[bool] = Field(default=True, description="whether to shuffle data in validation set")
+    batch_size_val: Optional[int] = Field(default=1, description="batch size of validation set")
 
-class DataloadersParameters(BaseModel):
-    shuffle_train: Optional[bool] = Field(None, description="whether to shuffle data in train set")
-    batch_size_train: Optional[int] = Field(None, description="batch size of train set")
-
-    shuffle_val: Optional[bool] = Field(None, description="whether to shuffle data in validation set")
-    batch_size_val: Optional[int] = Field(None, description="batch size of validation set")
-
-    shuffle_inference: Optional[bool] = Field(None, description="whether to shuffle data during inference")
-    batch_size_inference: Optional[int] = Field(None, description="batch size for inference")
+    shuffle_inference: Optional[bool] = Field(default=False, description="whether to shuffle data during inference")
+    batch_size_inference: Optional[int] = Field(default=1, description="batch size for inference")
 
     num_workers: Optional[int] = Field(None, description="number of workers")
     pin_memory: Optional[bool] = Field(None, description="memory pinning")
-    val_pct: Optional[float] = Field(None, description="percentage of data to use for validation")
+    val_pct: Optional[float] = Field(default=0.2, description="percentage of data to use for validation")
 
 
-class TrainingParameters(BaseModel):
-    network: DLSIANetwork
-    num_classes: int = Field(description="number of classes as output channel")
-    num_epochs: int = Field(description="number of epochs")
-    optimizer: Optimizer
-    criterion: Criterion
-    learning_rate: float = Field(description='learning rate')
-    
-    activation: Optional[Activation] = None
-    normalization: Optional[Normalization] = None
-    convolution: Optional[Convolution] = None
-    msdnet_parameters: Optional[MSDNetParameters] = None
-    tunet_parameters: Optional[TUNetParameters] = None 
-    tunet3plus_parameters: Optional[TUNet3PlusParameters] = None
+#===========================================Network-specific Parameters===========================================
+class MSDNetParameters(TrainingParameters):
+    layer_width: Optional[int] = Field(default=1, description="layer width of MSDNet")    
+    num_layers: Optional[int] = Field(default=3, description="number of layers for MSDNet")
+    custom_dilation: Optional[bool] = Field(default=False, description="whether to customize dilation for MSDNet")
+    max_dilation: Optional[int] = Field(default=5, description="maximum dilation for MSDNet")
+    dilation_array: Optional[List[int]] = Field(default=None, description="customized dilation array for MSDNet")
 
-    dataloaders: Optional[DataloadersParameters] = None
+class TUNetParameters(TrainingParameters):    
+    depth: Optional[int] = Field(default=4, description='the depth of the UNet')
+    base_channels: Optional[int] = Field(default=8, description='the number of initial channels for UNet')
+    growth_rate: Optional[int] = Field(default=1, description='multiplicative growth factor of number of '\
+                                       'channels per layer of depth for UNet')
+    hidden_rate: Optional[int] = Field(default=1, description='multiplicative growth factor of channels within'\
+                                       ' each layer for UNet')
+
+class TUNet3PlusParameters(TUNetParameters):    
+    carryover_channels: Optional[int] = Field(default=8, description='the number of channels in each skip '\
+                                              'connection for UNet3+')

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -40,12 +40,12 @@ class MSDNetParameters(TrainingParameters):
 
 class TUNetParameters(TrainingParameters):    
     depth: Optional[int] = Field(default=4, description='the depth of the UNet')
-    base_channels: Optional[int] = Field(default=8, description='the number of initial channels for UNet')
-    growth_rate: Optional[int] = Field(default=1, description='multiplicative growth factor of number of '\
+    base_channels: Optional[int] = Field(default=32, description='the number of initial channels for UNet')
+    growth_rate: Optional[int] = Field(default=2, description='multiplicative growth factor of number of '\
                                        'channels per layer of depth for UNet')
     hidden_rate: Optional[int] = Field(default=1, description='multiplicative growth factor of channels within'\
                                        ' each layer for UNet')
 
 class TUNet3PlusParameters(TUNetParameters):    
-    carryover_channels: Optional[int] = Field(default=8, description='the number of channels in each skip '\
+    carryover_channels: Optional[int] = Field(default=32, description='the number of channels in each skip '\
                                               'connection for UNet3+')

--- a/src/seg_utils.py
+++ b/src/seg_utils.py
@@ -329,5 +329,5 @@ def segment(net, device, inference_loader):
                 seg = preds
             else:
                 seg = np.concatenate((seg, preds), axis = 0)
-    print(seg.shape)
+    print(f'Result array shape: {seg.shape}')
     return seg

--- a/src/segment.py
+++ b/src/segment.py
@@ -1,57 +1,60 @@
-import argparse
-import json
-
-from parameters import TrainingParameters
-from tiled_dataset import InferenceDataset
-
-import torch
-from torchvision import transforms
-from torch.utils.data import DataLoader
-
-from network import load_network
-from seg_utils import segment
-from utils import save_seg_to_tiled
+import  argparse
+from    network             import  load_network
+from    parameters          import  MSDNetParameters, TUNetParameters, TUNet3PlusParameters
+from    seg_utils           import  segment
+from    tiled_dataset       import  TiledDataset
+import  torch
+from    torch.utils.data    import  DataLoader
+from    torchvision         import  transforms
+from    utils               import  save_seg_to_tiled
+import  yaml
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('data_tiled_uri', help='tiled uri to training data')
-    parser.add_argument('mask_tiled_uri', help='tiled uri to mask')
-    parser.add_argument('seg_tiled_uri', help='tiled uri to segmentation result')
-    parser.add_argument('data_tiled_api_key', help='tiled api key for training data')
-    parser.add_argument('mask_tiled_api_key', help='tiled api key for mask')
-    parser.add_argument('seg_tiled_api_key', help='tiled api key for segmentation result')   
-    parser.add_argument('mask_idx', help='mask index from data')
-    parser.add_argument('save_path', help = 'save path for models and outputs')
-    parser.add_argument('uid', help='uid for segmentation instance')
-    parser.add_argument('parameters', help='training parameters')
-    
+    parser.add_argument('yaml_path', type=str, help='path of yaml file for parameters')
     args = parser.parse_args()
 
-    # Load parameters
-    parameters = TrainingParameters(**json.loads(args.parameters))
+    # Open the YAML file for all parameters
+    with open(args.yaml_path, 'r') as file:
+        # Load parameters
+        parameters = yaml.safe_load(file)
+
+    # Detect which model we have, then load corresponding parameters 
+    raw_parameters = parameters['model_parameters']
+    network = raw_parameters['network']
+
+    model_parameters = None
+    if network == 'MSDNet':
+        model_parameters = MSDNetParameters(**raw_parameters)
+    elif network == 'TUNet':
+        model_parameters = TUNetParameters(**raw_parameters)
+    elif network == 'TUNet3+':
+        model_parameters = TUNet3PlusParameters(**raw_parameters)
     
-    dataset = InferenceDataset(
-        data_tiled_uri=args.data_tiled_uri,
-        mask_tiled_uri=args.mask_tiled_uri,
-        seg_tiled_uri=args.seg_tiled_uri,
-        mask_idx=json.loads(args.mask_idx), # Convert str to list
-        data_tiled_api_key=args.data_tiled_api_key,
-        mask_tiled_api_key=args.mask_tiled_api_key,
-        seg_tiled_api_key=args.seg_tiled_api_key,
+    assert model_parameters, f"Received Unsupported Network: {network}"
+    
+    print('Parameters loaded successfully.')
+
+    
+    dataset = TiledDataset(
+        data_tiled_uri=parameters['data_tiled_uri'],
+        mask_idx=parameters['mask_idx'], # Keeping this for a quick inference for now, in future this will be out with updates from app.
+        data_tiled_api_key=parameters['data_tiled_api_key'],
         transform=transforms.ToTensor()
         )
+    
     # Set Dataloader parameters (Note: we randomly shuffle the training set upon each pass)
-    inference_loader_params = {'batch_size': parameters.dataloaders.batch_size_inference,
-                               'shuffle': parameters.dataloaders.shuffle_inference}
+    inference_loader_params = {'batch_size': model_parameters.batch_size_inference,
+                               'shuffle': model_parameters.shuffle_inference}
     # Build Dataloaders
     inference_loader = DataLoader(dataset, **inference_loader_params)
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     # Load Network
-    model_params_path = f'{args.save_path}/{args.uid}_{parameters.network}.pt'
-    net = load_network(parameters.network, model_params_path)
+    model_params_path = f"{parameters['save_path']}/{parameters['uid']}_{network}.pt"
+    net = load_network(network, model_params_path)
 
     # Start segmentation
     seg_result = segment(net, device, inference_loader)
@@ -59,6 +62,14 @@ if __name__ == '__main__':
     # Save results back to Tiled
     # TODO: Change the hard-coding of container keys
     container_keys = ["mlex_store", 'rec20190524_085542_clay_testZMQ_8bit', 'results']
-    container_keys.append(args.uid)
     
-    seg_result_uri, seg_result_metadata = save_seg_to_tiled(seg_result, dataset, container_keys, args.uid, parameters.network)
+    
+    seg_result_uri, seg_result_metadata = save_seg_to_tiled(seg_result, 
+                                                            parameters['data_tiled_uri'], 
+                                                            parameters['mask_tiled_uri'],
+                                                            parameters['seg_tiled_uri'],
+                                                            parameters['seg_tiled_api_key'], 
+                                                            container_keys, 
+                                                            parameters['uid'], 
+                                                            network
+                                                            )

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -29,7 +29,7 @@ class TiledDataset(torch.utils.data.Dataset):
             self.mask_client = from_uri(mask_tiled_uri, api_key=mask_tiled_api_key)
         else:
             self.mask_client = None
-        self.mask_idx = list(mask_idx)
+        self.mask_idx = list(mask_idx) if mask_idx else []
         self.shift = int(shift)
         self.transform = transform
 

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -1,12 +1,12 @@
 import torch
 from tiled.client import from_uri
 
-class TrainingDataset(torch.utils.data.Dataset):
+class TiledDataset(torch.utils.data.Dataset):
     def __init__(
             self,
             data_tiled_uri,
-            mask_tiled_uri,
-            mask_idx,
+            mask_tiled_uri=None,
+            mask_idx=None,
             data_tiled_api_key=None,
             mask_tiled_api_key=None,
             shift=0,
@@ -25,51 +25,12 @@ class TrainingDataset(torch.utils.data.Dataset):
             ml_data:        tuple, (data_tensor, mask_tensor)
         '''
         self.data_client = from_uri(data_tiled_uri, api_key=data_tiled_api_key)
-        self.mask_client = from_uri(mask_tiled_uri, api_key=mask_tiled_api_key)
+        if mask_tiled_uri:
+            self.mask_client = from_uri(mask_tiled_uri, api_key=mask_tiled_api_key)
+        else:
+            self.mask_client = None
         self.mask_idx = list(mask_idx)
         self.shift = int(shift)
-        self.transform = transform
-
-    def __len__(self):
-        return len(self.mask_client)
-
-    def __getitem__(self, idx):
-        data = self.data_client[self.mask_idx[idx],]
-        mask = self.mask_client[idx,].astype('int') - self.shift # Conversion to int is needed as switching unlabeled pixels to -1 would cause trouble in uint8 format
-        if self.transform:
-            return self.transform(data), mask
-        else:
-            return data, mask
-        
-class InferenceDataset(torch.utils.data.Dataset):
-    def __init__(
-            self,
-            data_tiled_uri,
-            mask_tiled_uri,
-            seg_tiled_uri,
-            mask_idx,
-            data_tiled_api_key=None,
-            mask_tiled_api_key=None,
-            seg_tiled_api_key=None,
-            transform=None):
-        '''
-        Args:
-            data_tiled_uri:      str,    Tiled URI of the input data
-            mask_tiled_uri:      str,    Tiled URI of mask
-            seg_tiled_uri:       str,    Tiled URI of segmentation results
-            mask_idx:            list,   List for slice indexs that maps the mask to corresponding input images, used for slicing here  
-            data_tiled_api_key:  str,    Tiled API key for input data access
-            mask_tiled_api_key:  str,    Tiled API key for mask access
-            seg_tiled_api_key:   str,    Tiled API key for segmentation results
-            transform:           callable, if not given return PIL image
-
-        Return:
-            ml_data:             data_tensor
-        '''
-        self.data_client = from_uri(data_tiled_uri, api_key=data_tiled_api_key)
-        self.mask_client = from_uri(mask_tiled_uri, api_key=mask_tiled_api_key)
-        self.seg_client = from_uri(seg_tiled_uri, api_key=seg_tiled_api_key)
-        self.mask_idx = list(mask_idx)
         self.transform = transform
 
     def __len__(self):
@@ -77,7 +38,14 @@ class InferenceDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, idx):
         data = self.data_client[self.mask_idx[idx],]
-        if self.transform:
-            return self.transform(data)
+        if self.mask_client:
+            mask = self.mask_client[idx,].astype('int') - self.shift # Conversion to int is needed as switching unlabeled pixels to -1 would cause trouble in uint8 format
+            if self.transform:
+                return self.transform(data), mask
+            else:
+                return data, mask
         else:
-            return data
+            if self.transform:
+                return self.transform(data)
+            else:
+                return data

--- a/src/train.py
+++ b/src/train.py
@@ -1,20 +1,14 @@
-import argparse
-import json
-import os
-import yaml
-
-
-import torch
-import torch.nn as nn
-import torch.optim as optim
-from torchvision import transforms
-
-from parameters import MSDNetParameters, TUNetParameters, TUNet3PlusParameters
-from tiled_dataset import TrainingDataset
-from utils import create_directory
-from network import build_network
-from seg_utils import train_val_split, train_segmentation
-
+import  argparse
+from    network         import  build_network
+from    parameters      import  MSDNetParameters, TUNetParameters, TUNet3PlusParameters
+from    seg_utils       import  train_val_split, train_segmentation
+from    tiled_dataset   import  TiledDataset
+import  torch
+import  torch.nn        as      nn
+import  torch.optim     as      optim
+from    torchvision     import  transforms
+from    utils           import  create_directory
+import  yaml
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -45,7 +39,7 @@ if __name__ == '__main__':
     # Create Result Directory if not existed
     create_directory(parameters['save_path'])
     
-    dataset = TrainingDataset(
+    dataset = TiledDataset(
         data_tiled_uri=parameters['data_tiled_uri'],
         mask_tiled_uri=parameters['mask_tiled_uri'],
         mask_idx=parameters['mask_idx'],

--- a/src/train.py
+++ b/src/train.py
@@ -1,13 +1,15 @@
 import argparse
 import json
 import os
+import yaml
+
 
 import torch
 import torch.nn as nn
 import torch.optim as optim
 from torchvision import transforms
 
-from parameters import TrainingParameters
+from parameters import MSDNetParameters, TUNetParameters, TUNet3PlusParameters
 from tiled_dataset import TrainingDataset
 from utils import create_directory
 from network import build_network
@@ -16,49 +18,61 @@ from seg_utils import train_val_split, train_segmentation
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('data_tiled_uri', help='tiled uri to training data')
-    parser.add_argument('mask_tiled_uri', help='tiled uri to mask')
-    parser.add_argument('data_tiled_api_key', help='tiled api key for training data')
-    parser.add_argument('mask_tiled_api_key', help='tiled api key for mask')
-    parser.add_argument('mask_idx', help='mask index from data')
-    parser.add_argument('shift', help='pixel shifts for mask')
-    parser.add_argument('save_path', help = 'save path for models and outputs')
-    parser.add_argument('uid', help='uid for segmentation instance')
-    parser.add_argument('parameters', help='training parameters')
-    
+    parser.add_argument('yaml_path', type=str, help='path of yaml file for parameters')
     args = parser.parse_args()
 
-    # Create Result Directory if not existed
-    create_directory(args.save_path)
+    # Open the YAML file for all parameters
+    with open(args.yaml_path, 'r') as file:
+        # Load parameters
+        parameters = yaml.safe_load(file)
 
-    # Load parameters
-    parameters = TrainingParameters(**json.loads(args.parameters))
+    # Detect which model we have, then load corresponding parameters 
+    raw_parameters = parameters['model_parameters']
+    network = raw_parameters['network']
+
+    model_parameters = None
+    if network == 'MSDNet':
+        model_parameters = MSDNetParameters(**raw_parameters)
+    elif network == 'TUNet':
+        model_parameters = TUNetParameters(**raw_parameters)
+    elif network == 'TUNet3+':
+        model_parameters = TUNet3PlusParameters(**raw_parameters)
+    
+    assert model_parameters, f"Received Unsupported Network: {network}"
+    
+    print('Parameters loaded successfully.')
+
+    # Create Result Directory if not existed
+    create_directory(parameters['save_path'])
     
     dataset = TrainingDataset(
-        data_tiled_uri=args.data_tiled_uri,
-        mask_tiled_uri=args.mask_tiled_uri,
-        mask_idx=json.loads(args.mask_idx), # Convert str to list
-        data_tiled_api_key=args.data_tiled_api_key,
-        mask_tiled_api_key=args.mask_tiled_api_key,
-        shift=args.shift,
+        data_tiled_uri=parameters['data_tiled_uri'],
+        mask_tiled_uri=parameters['mask_tiled_uri'],
+        mask_idx=parameters['mask_idx'],
+        data_tiled_api_key=parameters['data_tiled_api_key'],
+        mask_tiled_api_key=parameters['mask_tiled_api_key'],
+        shift=parameters['shift'],
         transform=transforms.ToTensor()
         )
 
-    train_loader, val_loader = train_val_split(dataset, parameters.dataloaders)
+    train_loader, val_loader = train_val_split(dataset, model_parameters)
     
     # Build network
     net = build_network(
-        network=parameters.network,
+        network=network,
         data_shape=dataset.data_client.shape,
-        num_classes=parameters.num_classes,
-        parameters=parameters,
+        num_classes=model_parameters.num_classes,
+        parameters=model_parameters,
         )
 
     # Define criterion and optimizer
-    criterion = getattr(nn, parameters.criterion.value)
-    criterion = criterion(ignore_index=-1, size_average=None)    
-    optimizer = getattr(optim, parameters.optimizer.value)
-    optimizer = optimizer(net.parameters(), lr = parameters.learning_rate)
+    criterion = getattr(nn, model_parameters.criterion)
+    criterion = criterion(weight=model_parameters.weights,
+                          ignore_index=-1, 
+                          size_average=None
+                          )    
+    optimizer = getattr(optim, model_parameters.optimizer)
+    optimizer = optimizer(net.parameters(), lr = model_parameters.learning_rate)
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -66,11 +80,11 @@ if __name__ == '__main__':
         net,
         train_loader,
         val_loader,
-        parameters.num_epochs,
+        model_parameters.num_epochs,
         criterion,
         optimizer,
         device,
-        savepath=args.save_path,
+        savepath=parameters['save_path'],
         saveevery=None,
         scheduler=None,
         show=0,
@@ -79,10 +93,10 @@ if __name__ == '__main__':
         )
 
     # Save network parameters
-    model_params_path = f'{args.save_path}/{args.uid}_{parameters.network}.pt'
+    model_params_path = f"{parameters['save_path']}/{parameters['uid']}_{network}.pt"
     net.save_network_parameters(model_params_path)
 
-    print('Network Training Successful.')
+    print(f'{network} trained successfully.')
     # Clear out unnecessary variables from device memory
     torch.cuda.empty_cache()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+from tiled.client import from_uri
 
 # Create directory
 def create_directory(path):
@@ -10,13 +11,19 @@ def create_directory(path):
 
 
 # Tiled Saving
-def save_seg_to_tiled(seg_result, 
-                      tiled_dataset,
+def save_seg_to_tiled(seg_result,
+                      data_tiled_uri,
+                      mask_tiled_uri,
+                      seg_tiled_uri,
+                      seg_tiled_api_key,
                       container_keys,
-                      uuid,
+                      uid,
                       model,
                       ):
-    last_container = tiled_dataset.seg_client
+    
+    last_container = from_uri(seg_tiled_uri, api_key=seg_tiled_api_key)
+    container_keys.append(uid)
+    
     for key in container_keys:
         if key not in last_container.keys():
             last_container = last_container.create_container(key=key)
@@ -24,9 +31,9 @@ def save_seg_to_tiled(seg_result,
             last_container = last_container[key]
 
     metadata={
-        'data_tiled_uri': tiled_dataset.data_client.uri,
-        'mask_uri': tiled_dataset.mask_client.uri, 
-        'uuid': uuid,
+        'data_tiled_uri': data_tiled_uri,
+        'mask_uri': mask_tiled_uri, 
+        'uid': uid,
         'model': model, 
         }
     seg_result = last_container.write_array(key="seg_result", array=seg_result, metadata=metadata)

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,9 @@ import os
 def create_directory(path):
     if not os.path.exists(path):
         os.makedirs(path)
-        print(f"Local Directory '{path}' created.")
+        print(f"Local directory '{path}' created.")
+    else:
+        print(f"Local directory '{path}' already exsists.")
 
 
 # Tiled Saving


### PR DESCRIPTION
This PR covers changes as a reflection to the 2nd Diamond Hackathon's discussion.

### Feature Upgrades

- [x] Refactored the Parameter Class for Pydantic BaseModel to lift the nested structure from last version, thanks to @dylanmcreynolds !
- [x] I/O: Now both `train.py` and `segment.py` will only take one argument `yaml_file_path`.
- [x] Tiled Dataset: The `InferenceDataset` has been taken out and `TrainingDataset` has been modified to a unified `TiledDataset` which will handle both training and inference.
- [x] Testing: Example yaml files have been provided as a template under a new directory.

### To Test:

1. Modify the `tiled_api_key` for all clients under each example yaml file.
2. Modify the `uid` if necessary.
3. In terminal, `make train_tunet`
4. In terminal, `make segment_tunet`