### PR TITLE
fixes to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cryptography
-dlsia
-pydantic
-tiled[client]
+dlsia==0.3.0
+pydantic==2.6.3
+tiled[client]==0.1.0a114


### PR DESCRIPTION
This small PR does a few things for the requirements.txt.

- Removes `cryptography`...I couldn't find it used in the code
- Pins `dlsia`, `pydantic` and `tiled`. This protects us from having the rug pull out from underneath us by some breaking change. In general it's nice to leave dependencies un-pinned for ongoing development, and then pin them for testing and deployment. This `requirements.txt` is used for both, and it's better safe than sorry.