### PR TITLE
Added Tiled saving frame on the fly.

### DIFF
--- a/example_yamls/example_msdnet_customdil.yaml
+++ b/example_yamls/example_msdnet_customdil.yaml
@@ -8,7 +8,8 @@ io_parameters:
   mask_tiled_api_key: 
   seg_tiled_uri: http://0.0.0.0:8888/api/v1/metadata/mlex_store/rec20190524_085542_clay_testZMQ_8bit/results
   seg_tiled_api_key: 
-  uid: uid0022
+  uid_save: 
+  uid_retrieve: 
 
 model_parameters:
   network: "MSDNet"
@@ -16,7 +17,7 @@ model_parameters:
   num_epochs: 3
   optimizer: "Adam"
   criterion: "CrossEntropyLoss"
-  weights: [1.0, 2.0, 4.0]
+  weights: "[1.0, 2.0, 0.5]"
   learning_rate: 0.1
   activation: "ReLU"
   normalization: "BatchNorm2d"
@@ -37,4 +38,4 @@ model_parameters:
   layer_width: 1
   num_layers: 3
   custom_dilation: True
-  dilation_array: [1, 2, 4]
+  dilation_array: "[1, 2, 4]"

--- a/example_yamls/example_msdnet_maxdil.yaml
+++ b/example_yamls/example_msdnet_maxdil.yaml
@@ -8,7 +8,8 @@ io_parameters:
   mask_tiled_api_key: 
   seg_tiled_uri: http://0.0.0.0:8888/api/v1/metadata/mlex_store/rec20190524_085542_clay_testZMQ_8bit/results
   seg_tiled_api_key: 
-  uid: uid0021
+  uid_save: 
+  uid_retrieve: 
 
 model_parameters:
   network: "MSDNet"
@@ -16,7 +17,7 @@ model_parameters:
   num_epochs: 3
   optimizer: "Adam"
   criterion: "CrossEntropyLoss"
-  weights: [1.0, 2.0, 0.5]
+  weights: "[1.0, 2.0, 0.5]"
   learning_rate: 0.1
   activation: "ReLU"
   normalization: "BatchNorm2d"
@@ -31,7 +32,8 @@ model_parameters:
 
   batch_size_val: 2
 
-  batch_size_inference: 1
+  batch_size_inference: 3
+  
   val_pct: 0.2
 
   layer_width: 1

--- a/example_yamls/example_smsnet_ensemble.yaml
+++ b/example_yamls/example_smsnet_ensemble.yaml
@@ -8,7 +8,8 @@ io_parameters:
   mask_tiled_api_key: 
   seg_tiled_uri: http://0.0.0.0:8888/api/v1/metadata/mlex_store/rec20190524_085542_clay_testZMQ_8bit/results
   seg_tiled_api_key: 
-  uid: uid0020
+  uid_save: 
+  uid_retrieve: 
 
 model_parameters:
   network: "SMSNetEnsemble"
@@ -16,7 +17,7 @@ model_parameters:
   num_epochs: 3
   optimizer: "Adam"
   criterion: "CrossEntropyLoss"
-  weights: [2.0, 1.0, 0.5]
+  weights: "[1.0, 2.0, 0.5]"
   learning_rate: 0.1
   activation: "ReLU"
   normalization: "BatchNorm2d"
@@ -31,7 +32,7 @@ model_parameters:
 
   batch_size_val: 1
 
-  batch_size_inference: 1
+  batch_size_inference: 2
   val_pct: 0.2
 
   num_networks: 3
@@ -39,5 +40,5 @@ model_parameters:
   alpha: 0.0
   gamma: 0.0
   hidden_channels: null
-  dilation_choices: [1, 2, 3]
+  dilation_choices: "[1, 2, 3]"
   max_trial: 3

--- a/example_yamls/example_tunet.yaml
+++ b/example_yamls/example_tunet.yaml
@@ -8,7 +8,8 @@ io_parameters:
   mask_tiled_api_key: 
   seg_tiled_uri: http://0.0.0.0:8888/api/v1/metadata/mlex_store/rec20190524_085542_clay_testZMQ_8bit/results
   seg_tiled_api_key: 
-  uid: uid0020
+  uid_save: 
+  uid_retrieve: 
 
 model_parameters:
   network: "TUNet"
@@ -16,22 +17,22 @@ model_parameters:
   num_epochs: 3
   optimizer: "Adam"
   criterion: "CrossEntropyLoss"
-  weights: [1, 2, 4]
+  weights: "[1.0, 2.0, 0.5]"
   learning_rate: 0.1
   activation: "ReLU"
   normalization: "BatchNorm2d"
   convolution: "Conv2d"
 
-  qlty_window: 512
-  qlty_step: 100
-  qlty_border: 3
+  qlty_window: 64
+  qlty_step: 32
+  qlty_border: 8
   
   shuffle_train: True
   batch_size_train: 1
 
   batch_size_val: 1
 
-  batch_size_inference: 1
+  batch_size_inference: 2
   val_pct: 0.2
 
   depth: 4

--- a/example_yamls/example_tunet3plus.yaml
+++ b/example_yamls/example_tunet3plus.yaml
@@ -8,7 +8,8 @@ io_parameters:
   mask_tiled_api_key: 
   seg_tiled_uri: http://0.0.0.0:8888/api/v1/metadata/mlex_store/rec20190524_085542_clay_testZMQ_8bit/results
   seg_tiled_api_key: 
-  uid: uid0020
+  uid_save: 
+  uid_retrieve: 
 
 model_parameters:
   network: "TUNet3+"
@@ -16,15 +17,15 @@ model_parameters:
   num_epochs: 3
   optimizer: "Adam"
   criterion: "CrossEntropyLoss"
-  weights: [1, 2, 4]
+  weights: "[1.0, 2.0, 0.5]"
   learning_rate: 0.1
   activation: "ReLU"
   normalization: "BatchNorm2d"
   convolution: "Conv2d"
 
-  qlty_window: 512
-  qlty_step: 100
-  qlty_border: 3
+  qlty_window: 64
+  qlty_step: 32
+  qlty_border: 8
   
   shuffle_train: True
   batch_size_train: 1

--- a/src/network.py
+++ b/src/network.py
@@ -33,7 +33,8 @@ def build_msdnet(
             convolution=convolution
             )
     else:
-        dilation_array = np.array(msdnet_parameters.dilation_array)
+        dilation_array = [int(x) for x in msdnet_parameters.dilation_array.strip('[]').split(', ')]
+        dilation_array = np.array(dilation_array)
         logging.info(f'Using custom dilation: {dilation_array}')
         network = msdnet.MixedScaleDenseNetwork(
             in_channels=in_channels,
@@ -169,6 +170,7 @@ def build_smsnet_ensemble(
         ensemble_parameters,
         ):
 
+    dilation_choices = [int(x) for x in ensemble_parameters.dilation_choices.strip('[]').split(', ')]
     list_of_networks = construct_2dsms_ensembler(
         n_networks=ensemble_parameters.num_networks,
         in_channels=in_channels,
@@ -177,7 +179,7 @@ def build_smsnet_ensemble(
         alpha=ensemble_parameters.alpha,
         gamma=ensemble_parameters.gamma,
         hidden_channels=ensemble_parameters.hidden_channels,
-        dilation_choices=ensemble_parameters.dilation_choices,
+        dilation_choices=dilation_choices,
         parameter_bounds=None,
         max_trial=ensemble_parameters.max_trial,
         network_type='Classification',

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional
 
 #===========================================I/O Related Parameters===========================================#
 class IOParameters(BaseModel):
@@ -9,7 +9,8 @@ class IOParameters(BaseModel):
     mask_tiled_api_key: Optional[str] = Field(default=None, description="tiled api key for masks")
     seg_tiled_uri: Optional[str] = Field(default=None, description="tiled uri for segmenation results")
     seg_tiled_api_key: Optional[str] = Field(default=None, description="tiled api key for segmentation results")
-    uid: str = Field(description="uid for the workflow")
+    uid_save: str = Field(description="uid to save models, metrics and etc")
+    uid_retrieve: str = Field(description="uid to retrieve models")
 
 #===========================================General Parameters===========================================#
 class TrainingParameters(BaseModel):
@@ -18,7 +19,7 @@ class TrainingParameters(BaseModel):
     num_epochs: int = Field(default=10, description="number of epochs")
     optimizer: str = Field(default="Adam", description="optimizer used for training")
     criterion: str = Field(default="CrossEntropyLoss", description="criterion for loss")
-    weights: Optional[List[float]] = Field(default=None, description="weights per class for imbalanced labeling")
+    weights: Optional[str] = Field(default=None, description="weights per class for imbalanced labeling")
     learning_rate: float = Field(default=1e-2, description='learning rate')
     
     activation: Optional[str] = Field(default="ReLU", description="activation function used in network")
@@ -49,7 +50,7 @@ class MSDNetParameters(TrainingParameters):
     num_layers: Optional[int] = Field(default=3, description="number of layers for MSDNet")
     custom_dilation: Optional[bool] = Field(default=False, description="whether to customize dilation for MSDNet")
     max_dilation: Optional[int] = Field(default=5, description="maximum dilation for MSDNet")
-    dilation_array: Optional[List[int]] = Field(default=None, description="customized dilation array for MSDNet")
+    dilation_array: Optional[str] = Field(default=None, description="customized dilation array for MSDNet")
 
 class TUNetParameters(TrainingParameters):    
     depth: Optional[int] = Field(default=4, description='the depth of the UNet')
@@ -69,5 +70,5 @@ class SMSNetEnsembleParameters(TrainingParameters):
     alpha: Optional[float] = Field(default=0.0, description="aplha used in ensemble")
     gamma: Optional[float] = Field(default=0.0, description="gamma used in ensemble")
     hidden_channels: Optional[int] = Field(default=None, description="hidden channels, limit from 3 to 20")
-    dilation_choices: Optional[List[int]] = Field(default=None, description="customized dilation choices")
+    dilation_choices: Optional[str] = Field(default=None, description="customized dilation choices")
     max_trial: Optional[int] = Field(default=10, description="max trial for the ensemble")

--- a/src/segment.py
+++ b/src/segment.py
@@ -1,14 +1,13 @@
 import  argparse
 import  glob
-from    network             import  load_network, baggin_smsnet_ensemble
-from    parameters          import  IOParameters, MSDNetParameters, TUNetParameters, TUNet3PlusParameters, SMSNetEnsembleParameters
-from    qlty.qlty2D         import  NCYXQuilt
-from    seg_utils           import  custom_collate, segment
-from    tiled_dataset       import  TiledDataset
+from    network                 import  load_network, baggin_smsnet_ensemble
+from    parameters              import  IOParameters, MSDNetParameters, TUNetParameters, TUNet3PlusParameters, SMSNetEnsembleParameters
+from    seg_utils               import  custom_collate, segment
+from    tiled_dataset           import  TiledDataset
 import  torch
-from    torch.utils.data    import  DataLoader
-from    torchvision         import  transforms
-from    utils               import  save_seg_to_tiled
+from    torch.utils.data        import  DataLoader
+from    torchvision             import  transforms
+from    utils                   import  allocate_array_space
 import  yaml
 
 
@@ -66,18 +65,24 @@ if __name__ == '__main__':
 
     # Load Network
     if network == 'SMSNetEnsemble':
-        net = baggin_smsnet_ensemble(io_parameters.uid)
+        net = baggin_smsnet_ensemble(io_parameters.uid_retrieve)
     else:
-        net_files = glob.glob(f"{io_parameters.uid}/*.pt")
+        net_files = glob.glob(f"{io_parameters.uid_retrieve}/*.pt")
         net = load_network(network, net_files[0])
 
-    # Start segmentation
-    seg_result = segment(net, device, inference_loader, dataset.qlty_object)
-    
-    seg_result_uri, seg_result_metadata = save_seg_to_tiled(seg_result, 
-                                                            dataset,
-                                                            io_parameters.seg_tiled_uri,
-                                                            io_parameters.seg_tiled_api_key,
-                                                            io_parameters.uid, 
-                                                            network
-                                                            )
+    # Allocate Result space in Tiled
+    seg_client = allocate_array_space(tiled_dataset=dataset,
+                                      seg_tiled_uri=io_parameters.seg_tiled_uri,
+                                      seg_tiled_api_key=io_parameters.seg_tiled_api_key,
+                                      uid=io_parameters.uid_save,
+                                      model=network,
+                                      array_name='seg_result',
+                                      )
+    print(f'Result space allocated in Tiled and segmentation will be saved in {seg_client.uri}.')
+
+    # Start segmentation and save frame by frame
+    frame_count = segment(net, device, inference_loader, dataset.qlty_object, seg_client)
+
+    assert frame_count == len(dataset)
+
+    print('Segmentation completed.')

--- a/src/train.py
+++ b/src/train.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     print('Parameters loaded successfully.')
 
     # Create Result Directory if not existed
-    create_directory(io_parameters.uid)
+    create_directory(io_parameters.uid_save)
 
     dataset = TiledDataset(
         data_tiled_uri=io_parameters.data_tiled_uri,
@@ -71,7 +71,10 @@ if __name__ == '__main__':
 
     # Define criterion and optimizer
     criterion = getattr(nn, model_parameters.criterion)
-    criterion = criterion(weight=torch.tensor(model_parameters.weights,dtype=torch.float),
+    # Convert the string to a list of floats
+    weights = [float(x) for x in model_parameters.weights.strip('[]').split(', ')]
+    weights = torch.tensor(weights,dtype=torch.float)
+    criterion = criterion(weight=weights,
                           ignore_index=-1, 
                           size_average=None
                           )    
@@ -90,7 +93,7 @@ if __name__ == '__main__':
             criterion,
             optimizer,
             device,
-            savepath=io_parameters.uid,
+            savepath=io_parameters.uid_save,
             saveevery=None,
             scheduler=None,
             show=0,
@@ -98,7 +101,7 @@ if __name__ == '__main__':
             clip_value=None
             )
         # Save network parameters
-        model_params_path = f"{io_parameters.uid}/{io_parameters.uid}_{network}{idx+1}.pt"
+        model_params_path = f"{io_parameters.uid_save}/{io_parameters.uid_save}_{network}{idx+1}.pt"
         net.save_network_parameters(model_params_path)
         # Clear out unnecessary variables from device memory
         torch.cuda.empty_cache()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,7 @@
 import os
 from tiled.client import from_uri
+from tiled.structures.array import ArrayStructure
+import numpy as np
 
 # Create directory
 def create_directory(path):
@@ -11,16 +13,21 @@ def create_directory(path):
 
 
 # Tiled Saving
-def save_seg_to_tiled(seg_result,
+def allocate_array_space(
                       tiled_dataset,
                       seg_tiled_uri,
                       seg_tiled_api_key,
                       uid,
                       model,
+                      array_name,
                       ):
     
     last_container = from_uri(seg_tiled_uri, api_key=seg_tiled_api_key)
     last_container = last_container.create_container(key=uid)
+    array_shape = tiled_dataset.mask_client.shape if tiled_dataset.mask_client else tiled_dataset.data_client.shape
+    structure = ArrayStructure.from_array(np.zeros(array_shape,dtype=np.int8))
+    # For now, only save image 1 by 1 regardless of the batch_size_inference.
+    structure.chunks = ((1,) * array_shape[0], (array_shape[1],), (array_shape[2],))
 
     metadata={
         'data_tiled_uri': tiled_dataset.data_tiled_uri,
@@ -29,6 +36,10 @@ def save_seg_to_tiled(seg_result,
         'uid': uid,
         'model': model, 
         }
-    seg_result = last_container.write_array(key="seg_result", array=seg_result, metadata=metadata)
-    print("Segmentaion result array saved in following uri: ", seg_result.uri)
-    return seg_result.uri, seg_result.metadata   
+
+    array_client = last_container.new(structure_family='array',
+                                      structure=structure,
+                                      key=array_name,
+                                      metadata=metadata,
+                                      )
+    return array_client


### PR DESCRIPTION
This PR covers 1 major feature upgrade and several minor changes:

### Feature Upgrade:
Added functions to pre-allocate array space on Tiled Client, and saving single frame on the fly during inference.

### Minor Changes:

1. Now 2 uids will be taken from yaml file: `uid_save` for model and metric saving, and `uid_retrieve` for model retrieval.
2. Added conversion codes to convert str of lists to np array, list, or float tensor when needed.

### To Test:

1. Modify uri and api_key in example yaml files
2. run make file commands 
3. In order to test full inference saving, select correct `uid_retrieve` for previous trained models, and comment out `mask_tiled_uri`, `mask_tiled_api_key` (or set them to `null` in yaml). 

### Note:

1. It would be worthwhile to try at least 1 full inference to see if all slices have been saved properly, eg. a very small MSDNet. In my test case, I encountered unstable connection to public tiled server due to spiky internet, and apparently there is no mechanism in code for recovery in such situation. Don't know if this would be a concern for the beam time.
As a reference, the error code I got was: `httpx.ReadError: [Errno 54] Connection reset by peer` 
2.  The SMSNet Ensemble methods should still be tested out as this hasn't been well addressed in my last PR due to time concern.