### PR TITLE
Specify directory for saving models and stats

### DIFF
--- a/example_yamls/example_msdnet_customdil.yaml
+++ b/example_yamls/example_msdnet_customdil.yaml
@@ -10,6 +10,7 @@ io_parameters:
   seg_tiled_api_key:
   uid_save:
   uid_retrieve:
+  models_dir: .
 
 model_parameters:
   network: "MSDNet"

--- a/example_yamls/example_msdnet_maxdil.yaml
+++ b/example_yamls/example_msdnet_maxdil.yaml
@@ -10,6 +10,7 @@ io_parameters:
   seg_tiled_api_key:
   uid_save:
   uid_retrieve:
+  models_dir: .
 
 model_parameters:
   network: "MSDNet"

--- a/example_yamls/example_smsnet_ensemble.yaml
+++ b/example_yamls/example_smsnet_ensemble.yaml
@@ -10,6 +10,7 @@ io_parameters:
   seg_tiled_api_key:
   uid_save:
   uid_retrieve:
+  models_dir: .
 
 model_parameters:
   network: "SMSNetEnsemble"

--- a/example_yamls/example_tunet.yaml
+++ b/example_yamls/example_tunet.yaml
@@ -10,6 +10,7 @@ io_parameters:
   seg_tiled_api_key:
   uid_save:
   uid_retrieve:
+  models_dir: .
 
 model_parameters:
   network: "TUNet"

--- a/example_yamls/example_tunet3plus.yaml
+++ b/example_yamls/example_tunet3plus.yaml
@@ -10,6 +10,7 @@ io_parameters:
   seg_tiled_api_key:
   uid_save:
   uid_retrieve:
+  models_dir: .
 
 model_parameters:
   network: "TUNet3+"

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -23,6 +23,9 @@ class IOParameters(BaseModel):
     uid_retrieve: Optional[str] = Field(
         description="optional, uid to retrieve models for inference"
     )
+    models_dir: Optional[str] = Field(
+        default=None, description="directory to save model results"
+    )
 
 
 # ===========================================General Parameters===========================================#

--- a/src/segment.py
+++ b/src/segment.py
@@ -1,5 +1,6 @@
 import argparse
 import glob
+import os
 
 import torch
 import yaml
@@ -78,11 +79,13 @@ if __name__ == "__main__":
     torch.cuda.empty_cache()
     print(f"Inference will be processed on: {device}")
 
+    model_dir = os.path.join(io_parameters.models_dir, io_parameters.uid_retrieve)
+
     # Load Network
     if network == "SMSNetEnsemble":
-        net = baggin_smsnet_ensemble(io_parameters.uid_retrieve)
+        net = baggin_smsnet_ensemble(model_dir)
     else:
-        net_files = glob.glob(f"{io_parameters.uid_retrieve}/*.pt")
+        net_files = glob.glob(os.path.join(model_dir, "*.pt"))
         net = load_network(network, net_files[0])
 
     # Allocate Result space in Tiled

--- a/src/train.py
+++ b/src/train.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import torch
 import torch.nn as nn
@@ -52,8 +53,9 @@ if __name__ == "__main__":
 
     print("Parameters loaded successfully.")
 
+    model_dir = os.path.join(io_parameters.models_dir, io_parameters.uid_save)
     # Create Result Directory if not existed
-    create_directory(io_parameters.uid_save)
+    create_directory(model_dir)
 
     dataset = TiledDataset(
         data_tiled_uri=io_parameters.data_tiled_uri,
@@ -110,7 +112,7 @@ if __name__ == "__main__":
             criterion,
             optimizer,
             device,
-            savepath=io_parameters.uid_save,
+            savepath=model_dir,
             saveevery=None,
             scheduler=None,
             show=0,
@@ -119,9 +121,10 @@ if __name__ == "__main__":
         )
         # Save network parameters
 
-        model_params_path = (
-            f"{io_parameters.uid_save}/{io_parameters.uid_save}_{network}{idx+1}.pt"
+        model_params_path = os.path.join(
+            model_dir, f"{io_parameters.uid_save}_{network}{idx+1}.pt"
         )
+
         print(f"!!!!!!!   model_params_path {model_params_path}")
 
         net.save_network_parameters(model_params_path)


### PR DESCRIPTION
Currently, models are saved into directories for wherever the models are running. We will need more control than this. This PR adds an additional parameter to the input parameters `models_dir`, which will be configured by the Dash application as well. 