### PR TITLE
call DLSIA’s Trainer and pass dvclive obj to it

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -7,8 +7,8 @@ import torch.optim as optim
 import yaml
 from torchvision import transforms
 
-from dvclive import Live
 from dlsia.core.train_scripts import Trainer
+from dvclive import Live
 from network import build_network
 from parameters import (
     IOParameters,
@@ -20,6 +20,7 @@ from parameters import (
 from seg_utils import crop_split_load, train_segmentation
 from tiled_dataset import TiledDataset
 from utils import create_directory
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/train.py
+++ b/src/train.py
@@ -5,10 +5,10 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import yaml
-from torchvision import transforms
-
 from dlsia.core.train_scripts import Trainer
 from dvclive import Live
+from torchvision import transforms
+
 from network import build_network
 from parameters import (
     IOParameters,
@@ -20,7 +20,6 @@ from parameters import (
 from seg_utils import crop_split_load, train_segmentation
 from tiled_dataset import TiledDataset
 from utils import create_directory
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/train.py
+++ b/src/train.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     criterion = criterion(weight=weights, ignore_index=-1, size_average=None)
 
     use_dvclive = True
-    use_savedvcexp= False
+    use_savedvcexp = False
 
     for idx, net in enumerate(networks):
         print(f"{network}: {idx+1}/{len(networks)}")
@@ -112,11 +112,11 @@ if __name__ == "__main__":
 
         if use_dvclive:
             dvclive_savepath = f"{model_dir}/dvc_metrics"
-            dvclive = Live(dvclive_savepath, report = "html", save_dvc_exp = use_savedvcexp)
+            dvclive = Live(dvclive_savepath, report="html", save_dvc_exp=use_savedvcexp)
         else:
             dvclive = None
 
-        trainer =   Trainer(
+        trainer = Trainer(
             net,
             train_loader,
             val_loader,
@@ -130,9 +130,9 @@ if __name__ == "__main__":
             scheduler=None,
             show=0,
             use_amp=False,
-            clip_value=None
+            clip_value=None,
         )
-        net, results = trainer.train_segmentation()   # training happens here
+        net, results = trainer.train_segmentation()  # training happens here
 
         # Save network parameters
         model_params_path = os.path.join(

--- a/src/train.py
+++ b/src/train.py
@@ -7,6 +7,8 @@ import torch.optim as optim
 import yaml
 from torchvision import transforms
 
+from dvclive import Live
+from dlsia.core.train_scripts import Trainer
 from network import build_network
 from parameters import (
     IOParameters,
@@ -18,8 +20,6 @@ from parameters import (
 from seg_utils import crop_split_load, train_segmentation
 from tiled_dataset import TiledDataset
 from utils import create_directory
-from dvclive import Live
-from dlsia.core.train_scripts import Trainer
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/train.py
+++ b/src/train.py
@@ -18,6 +18,8 @@ from parameters import (
 from seg_utils import crop_split_load, train_segmentation
 from tiled_dataset import TiledDataset
 from utils import create_directory
+from dvclive import Live
+from dlsia.core.train_scripts import Trainer
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -99,12 +101,22 @@ if __name__ == "__main__":
     weights = torch.tensor(weights, dtype=torch.float).to(device)
     criterion = criterion(weight=weights, ignore_index=-1, size_average=None)
 
+    use_dvclive = True
+    use_savedvcexp= False
+
     for idx, net in enumerate(networks):
         print(f"{network}: {idx+1}/{len(networks)}")
         optimizer = getattr(optim, model_parameters.optimizer)
         optimizer = optimizer(net.parameters(), lr=model_parameters.learning_rate)
         net = net.to(device)
-        net, results = train_segmentation(
+
+        if use_dvclive:
+            dvclive_savepath = f"{model_dir}/dvc_metrics"
+            dvclive = Live(dvclive_savepath, report = "html", save_dvc_exp = use_savedvcexp)
+        else:
+            dvclive = None
+
+        trainer =   Trainer(
             net,
             train_loader,
             val_loader,
@@ -112,15 +124,17 @@ if __name__ == "__main__":
             criterion,
             optimizer,
             device,
+            dvclive=dvclive,
             savepath=model_dir,
             saveevery=None,
             scheduler=None,
             show=0,
             use_amp=False,
-            clip_value=None,
+            clip_value=None
         )
-        # Save network parameters
+        net, results = trainer.train_segmentation()   # training happens here
 
+        # Save network parameters
         model_params_path = os.path.join(
             model_dir, f"{io_parameters.uid_save}_{network}{idx+1}.pt"
         )


### PR DESCRIPTION
As a new class called Trainer() has been added to DLSIA, we can call this class instead of using the previous train_segmentation() function in train.py. The main changes are summarized as follows:
```
from dlsia.core.train_scripts import Trainer
from dvclive import Live

dvclive= Live(...)
trainer = Trainer(..., dvclive=dvclive)
net, results = trainer.train_segmentation()
```