### PR TITLE
upgrade qlty from 0.1.6 to 0.1.7 and dlsia from 0.3.0 to 0.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-qlty==0.1.6
+qlty==0.1.7
 dvclive==3.44.0
-#dlsia==0.3.0
+dlsia==0.3.1
 pydantic==2.6.3
 tiled[client]==0.1.0a114


### PR DESCRIPTION
Two packages (qlty and dlsia) in requirements.txt are upgraded:
1. A new version of DLSIA (0.3.1) is released, with the Trainer() class added. Hence, **dlsia** is upgraded from 0.3.0 to **0.3.1**.
2. **qlty** should be upgraded from 0.1.6 to **0.1.7** to be compatible with dlsia 0.3.1.