### PR TITLE
Refactor `TiledDataset` into `TiledDataset` and `TiledMaskedDataset`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ isort==5.13.2
 pre-commit==3.6.2
 tiled[all]==0.1.0a114
 pytest
+starlette==0.38.2

--- a/src/_tests/conftest.py
+++ b/src/_tests/conftest.py
@@ -60,9 +60,11 @@ def tiled_dataset(client):
 
 @pytest.fixture
 def tiled_masked_dataset(client):
+    mask_indices = client["uid0001"].metadata["mask_idx"]
     tiled_masked_dataset = TiledMaskedDataset(
         data_tiled_client=client["reconstructions"]["recon1"],
-        mask_tiled_client=client["uid0001"],
+        mask_tiled_client=client["uid0001"]["mask"],
+        selected_indices=mask_indices,
     )
     yield tiled_masked_dataset
 

--- a/src/_tests/test_1-tiled_dataset.py
+++ b/src/_tests/test_1-tiled_dataset.py
@@ -40,11 +40,13 @@ def test_tiled_dataset_selected_indices(client, selected_indices, expected_len):
 
 
 def test_tiled_masked_dataset(client):
+    mask_indices = client["uid0001"].metadata["mask_idx"]
     tiled_masked_dataset = TiledMaskedDataset(
         data_tiled_client=client["reconstructions"]["recon1"],
-        mask_tiled_client=client["uid0001"],
+        mask_tiled_client=client["uid0001"]["mask"],
+        selected_indices=mask_indices,
     )
-    mask_indices = client["uid0001"].metadata["mask_idx"]
+
     assert tiled_masked_dataset
     assert len(tiled_masked_dataset) == 2
     assert tiled_masked_dataset.shape == (2, 6, 6)

--- a/src/_tests/test_1-tiled_dataset.py
+++ b/src/_tests/test_1-tiled_dataset.py
@@ -1,78 +1,64 @@
 import numpy as np
 import pytest
 
-from ..tiled_dataset import TiledDataset
+from ..tiled_dataset import TiledDataset, TiledMaskedDataset
+
+
+def test_tiled_dataset(client):
+    tiled_dataset = TiledDataset(data_tiled_client=client["reconstructions"]["recon1"])
+    assert tiled_dataset
+    assert len(tiled_dataset) == 5
+    assert tiled_dataset.shape == (5, 6, 6)
+    # Check data
+    for idx in range(5):
+        assert tiled_dataset[idx].shape == (6, 6)
+        assert tiled_dataset[idx].dtype == np.uint8
+        assert np.array_equal(
+            tiled_dataset[idx], client["reconstructions"]["recon1"][idx,]
+        )
 
 
 @pytest.mark.parametrize(
-    "mask_client, is_training, is_full_inference, expected_len, expected_shape, expected_dtype, check_mask",
-    [
-        # Test with mask, during training
-        (
-            {"mask_client": "uid0001", "mask_idx": [1, 3]},
-            True,
-            False,
-            2,
-            (6, 6),
-            np.uint8,
-            True,
-        ),
-        # Test with mask, quick inference
-        (
-            {"mask_client": "uid0001", "mask_idx": [1, 3]},
-            False,
-            False,
-            2,
-            (6, 6),
-            np.uint8,
-            False,
-        ),
-        # Test with mask, full inference
-        (
-            {"mask_client": "uid0001", "mask_idx": [1, 3]},
-            False,
-            True,
-            5,
-            (6, 6),
-            np.uint8,
-            False,
-        ),
-        # Test without mask, full inference
-        (None, False, True, 5, (6, 6), np.uint8, False),
-    ],
+    "selected_indices, expected_len", [(None, 5), ([0, 2, 4], 3), ([0, 1, 2, 3, 4], 5)]
 )
-def test_tiled_dataset(
-    client,
-    mask_client,
-    is_training,
-    is_full_inference,
-    expected_len,
-    expected_shape,
-    expected_dtype,
-    check_mask,
-):
-    mask_tiled_client = client[mask_client["mask_client"]] if mask_client else None
-
+def test_tiled_dataset_selected_indices(client, selected_indices, expected_len):
     tiled_dataset = TiledDataset(
         data_tiled_client=client["reconstructions"]["recon1"],
-        mask_tiled_client=mask_tiled_client,
-        is_training=is_training,
-        is_full_inference=is_full_inference,
+        selected_indices=selected_indices,
     )
-
     assert tiled_dataset
     assert len(tiled_dataset) == expected_len
+    assert tiled_dataset.shape == (expected_len, 6, 6)
+    # Check data for each index
+    for idx in range(expected_len):
+        assert tiled_dataset[idx].shape == (6, 6)
+        assert tiled_dataset[idx].dtype == np.uint8
+        mapped_idx = selected_indices[idx] if selected_indices else idx
+        assert np.array_equal(
+            tiled_dataset[idx], client["reconstructions"]["recon1"][mapped_idx,]
+        )
 
-    # Check data
-    if is_training:
-        assert len(tiled_dataset[0]) == 2  # data and mask
-        assert tiled_dataset[0][0].shape == expected_shape
-        assert tiled_dataset[0][0].dtype == expected_dtype
-        # Check mask
-        assert tiled_dataset[0][1].shape == expected_shape
-        assert tiled_dataset[0][1].dtype == np.int8
-        if check_mask:
-            assert np.all(tiled_dataset[0][1])  # should be all 1s
-    else:
-        assert tiled_dataset[0].shape == expected_shape
-        assert tiled_dataset[0].dtype == expected_dtype
+
+def test_tiled_masked_dataset(client):
+    tiled_masked_dataset = TiledMaskedDataset(
+        data_tiled_client=client["reconstructions"]["recon1"],
+        mask_tiled_client=client["uid0001"],
+    )
+    mask_indices = client["uid0001"].metadata["mask_idx"]
+    assert tiled_masked_dataset
+    assert len(tiled_masked_dataset) == 2
+    assert tiled_masked_dataset.shape == (2, 6, 6)
+    # Check data and mask
+    for idx in range(2):
+        mapped_idx = mask_indices[idx]
+        assert tiled_masked_dataset[idx][0].shape == (6, 6)
+        assert tiled_masked_dataset[idx][0].dtype == np.uint8
+        assert np.array_equal(
+            tiled_masked_dataset[idx][0],
+            client["reconstructions"]["recon1"][mapped_idx,],
+        )
+        assert tiled_masked_dataset[idx][1].shape == (6, 6)
+        assert tiled_masked_dataset[idx][1].dtype == np.int8
+        assert np.array_equal(
+            tiled_masked_dataset[idx][1], client["uid0001"]["mask"][idx,]
+        )

--- a/src/_tests/test_3-train.py
+++ b/src/_tests/test_3-train.py
@@ -153,14 +153,14 @@ def test_model_parameter_validation(model_parameters, parameters_dict):
 
 
 @pytest.fixture
-def raw_data(tiled_dataset):
-    data, _ = prepare_data_and_mask(tiled_dataset)
+def raw_data(tiled_masked_dataset):
+    data, _ = prepare_data_and_mask(tiled_masked_dataset)
     yield data
 
 
 @pytest.fixture
-def mask_array(tiled_dataset):
-    _, mask = prepare_data_and_mask(tiled_dataset)
+def mask_array(tiled_masked_dataset):
+    _, mask = prepare_data_and_mask(tiled_masked_dataset)
     yield mask
 
 

--- a/src/_tests/test_4-inference.py
+++ b/src/_tests/test_4-inference.py
@@ -21,12 +21,10 @@ def loaded_network(network_name, model_directory):
 
 
 @pytest.fixture
+# TODO: Duplication of previous fixture?
 def seg_tiled_dataset(client):
     tiled_dataset = TiledDataset(
         data_tiled_client=client["reconstructions"]["recon1"],
-        mask_tiled_client=client["uid0001"],
-        is_training=False,
-        is_full_inference=False,
     )
     yield tiled_dataset
 
@@ -53,11 +51,11 @@ def test_seg_client(seg_client, io_parameters, network_name):
         seg_client.uri
         == f"http://local-tiled-app/api/v1/metadata/results/{io_parameters.uid_save}/seg_result"
     )
-    assert seg_client.shape == (2, 6, 6)
+    assert seg_client.shape == (5, 6, 6)
     metadata = {
         "data_uri": "http://local-tiled-app/api/v1/metadata/reconstructions/recon1",
-        "mask_uri": "http://local-tiled-app/api/v1/metadata/uid0001/mask",
-        "mask_idx": [1, 3],
+        "mask_uri": None,
+        "mask_idx": None,
         "uid": io_parameters.uid_save,
         "model": network_name,
     }

--- a/src/segment.py
+++ b/src/segment.py
@@ -28,11 +28,10 @@ def full_inference(args):
     dataset = initialize_tiled_datasets(
         io_parameters,
         is_training=False,
-        is_full_inference=True,
     )
     qlty_object = NCYXQuilt(
-        X=dataset.data_client.shape[-1],
-        Y=dataset.data_client.shape[-2],
+        X=dataset.shape[-1],
+        Y=dataset.shape[-2],
         window=(model_parameters.qlty_window, model_parameters.qlty_window),
         step=(model_parameters.qlty_step, model_parameters.qlty_step),
         border=(model_parameters.qlty_border, model_parameters.qlty_border),

--- a/src/segment.py
+++ b/src/segment.py
@@ -6,12 +6,12 @@ import torch
 import yaml
 from qlty.qlty2D import NCYXQuilt
 
+from tiled_dataset import initialize_tiled_datasets
 from utils import (
     allocate_array_space,
     construct_dataloaders,
     ensure_parent_containers,
     find_device,
-    initialize_tiled_datasets,
     load_dlsia_network,
     normalization,
     qlty_crop,

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -1,4 +1,5 @@
 import torch
+from tiled.client import from_uri
 
 
 class TiledDataset(torch.utils.data.Dataset):
@@ -54,3 +55,33 @@ class TiledDataset(torch.utils.data.Dataset):
             else:
                 data = self.data_client[idx,]
                 return data
+
+
+def initialize_tiled_datasets(
+    io_parameters, is_training=False, is_full_inference=False
+):
+    """
+    This function takes tiled uris from the io_parameter class, build the client and construct TiledDataset.
+    Input:
+        io_parameters: class, all io parameters in pydantic class
+        is_training: bool, whether the dataset is used for training or inference
+        is_full_inference: bool, whether the process is used for full inference
+    Output:
+        dataset: class, TiledDataset
+
+    """
+    data_tiled_client = from_uri(
+        io_parameters.data_tiled_uri, api_key=io_parameters.data_tiled_api_key
+    )
+    mask_tiled_client = None
+    if io_parameters.mask_tiled_uri:
+        mask_tiled_client = from_uri(
+            io_parameters.mask_tiled_uri, api_key=io_parameters.mask_tiled_api_key
+        )
+    dataset = TiledDataset(
+        data_tiled_client=data_tiled_client,
+        mask_tiled_client=mask_tiled_client,
+        is_training=is_training,
+        is_full_inference=is_full_inference,
+    )
+    return dataset

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -83,7 +83,7 @@ def initialize_tiled_datasets(io_parameters, is_training=False):
             io_parameters.data_tiled_uri, api_key=io_parameters.data_tiled_api_key
         )
     except Exception as e:
-        raise ValueError(f"Error initializing data tiled client: {e}")
+        raise Exception(f"Error initializing data tiled client: {e}")
 
     if io_parameters.mask_tiled_uri:
         try:
@@ -105,8 +105,10 @@ def initialize_tiled_datasets(io_parameters, is_training=False):
                 )
             else:
                 dataset = TiledDataset(data_tiled_client, selected_indices)
+        except KeyError as e:
+            raise KeyError(f"Missing information in mask tiled client: {e}")
         except Exception as e:
-            raise ValueError(f"Error initializing mask tiled client: {e}")
+            raise Exception(f"Error initializing mask tiled client: {e}")
 
     else:
         dataset = TiledDataset(data_tiled_client=data_tiled_client)

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -92,14 +92,21 @@ def initialize_tiled_datasets(io_parameters, is_training=False):
     except Exception as e:
         raise ValueError(f"Error initializing data tiled client: {e}")
 
-    if is_training and io_parameters.mask_tiled_uri:
+    if io_parameters.mask_tiled_uri:
         try:
             mask_tiled_client = from_uri(
                 io_parameters.mask_tiled_uri, api_key=io_parameters.mask_tiled_api_key
             )
-            dataset = TiledMaskedDataset(data_tiled_client, mask_tiled_client)
+            masked_dataset = TiledMaskedDataset(data_tiled_client, mask_tiled_client)
         except Exception as e:
             raise ValueError(f"Error initializing mask tiled client: {e}")
+        if is_training:
+            dataset = masked_dataset
+        else:
+            dataset = TiledDataset(
+                masked_dataset.data_client, masked_dataset.selected_indices
+            )
+
     else:
         dataset = TiledDataset(data_tiled_client=data_tiled_client)
     return dataset

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -3,85 +3,103 @@ from tiled.client import from_uri
 
 
 class TiledDataset(torch.utils.data.Dataset):
+    """
+    PyTorch dataset class for data (or index-based subset of data) retrieved through Tiled.
 
-    def __init__(
-        self,
-        data_tiled_client,
-        mask_tiled_client=None,
-        is_training=False,
-        is_full_inference=False,
-    ):
-        """
-        Args:
-            data_tiled_uri:      str,    Tiled URI of the input data
-            data_tiled_api_key:  str,    Tiled API key for input data access
-            mask_tiled_uri:      str,    Tiled URI of mask
-            mask_tiled_api_key:  str,    Tiled API key for mask access
-            is_training:         bool,   Whether this is a training instance
-            is_full_inference:   bool,   Whether to perform full inference
+    Parameters:
+        data_tiled_client (tiled.client): The client object used to access the data through Tiled.
+        selected_indices (List[int]): List of indices to iterate over a subset of the data.
+    Attributes:
+        shape (Tuple[int]): The shape of the data set.
+    Methods:
+        __len__(): Returns the length of the dataset.
+        __getitem__(idx): Returns the data at the given index as a numpy array.
+    """
 
-        Return:
-            ml_data:        tuple, (data_tensor, mask_tensor)
-        """
-
+    def __init__(self, data_tiled_client, selected_indices=None):
         self.data_client = data_tiled_client
-        self.mask_client = None
-        if mask_tiled_client:
-            self.mask_client = mask_tiled_client["mask"]
-            self.mask_idx = [int(idx) for idx in mask_tiled_client.metadata["mask_idx"]]
-        else:
-            self.mask_client = None
-            self.mask_idx = None
-
-        self.is_training = is_training
-        self.is_full_inference = is_full_inference
+        self.selected_indices = selected_indices
 
     def __len__(self):
-        if self.is_full_inference:
-            return len(self.data_client)
-        else:
-            return len(self.mask_client)
+        if not (self.selected_indices is None):
+            return len(self.selected_indices)
+        return len(self.data_client)
 
     def __getitem__(self, idx):
-        if self.is_training:
-            data = self.data_client[self.mask_idx[idx],]
-            mask = self.mask_client[idx,]
-            return data, mask
-        else:
-            if not self.is_full_inference:
-                data = self.data_client[self.mask_idx[idx],]
-                return data
+        if not (self.selected_indices is None):
+            idx = self.selected_indices[idx]
+        data = self.data_client[idx,]
+        return data
 
-            else:
-                data = self.data_client[idx,]
-                return data
+    @property
+    def shape(self):
+        if not (self.selected_indices is None):
+            # Update shape of the data set based on the selected indices
+            # List / tuple conversion is needed for mutability
+            data_client_shape = list(self.data_client.shape)
+            data_client_shape[0] = len(self.selected_indices)
+            return tuple(data_client_shape)
+        return self.data_client.shape
 
 
-def initialize_tiled_datasets(
-    io_parameters, is_training=False, is_full_inference=False
-):
+class TiledMaskedDataset(TiledDataset):
     """
-    This function takes tiled uris from the io_parameter class, build the client and construct TiledDataset.
+        PyTorch dataset class for data and and subset of data retrieved through Tiled.
+    Args:
+        data_tiled_client (tiled.client): The tiled client for accessing the data.
+        mask_tiled_client (tiled.client): The tiled client for accessing segmentation masks.
+    Methods:
+        __len__(): Returns the length of the dataset.
+        __getitem__(idx): Returns the data and mask at the given index.
+    """
+
+    def __init__(self, data_tiled_client, mask_tiled_client):
+        if "mask_idx" not in mask_tiled_client.metadata:
+            raise KeyError(
+                "The mask client does not have the required 'mask_idx' metadata."
+            )
+
+        selected_indices = mask_tiled_client.metadata["mask_idx"]
+        super().__init__(data_tiled_client, selected_indices)
+
+        if "mask" not in mask_tiled_client.keys():
+            raise KeyError("The mask client does not have the required 'mask' key.")
+        self.mask_client = mask_tiled_client["mask"]
+
+    def __len__(self):
+        return len(self.mask_client)
+
+    def __getitem__(self, idx):
+        data = self.data_client[self.selected_indices[idx],]
+        mask = self.mask_client[idx,]
+        return data, mask
+
+
+def initialize_tiled_datasets(io_parameters, is_training=False):
+    """
+    This function takes Tiled configurations from the io_parameter class, builds the client and constructs TiledDataset.
     Input:
-        io_parameters: class, all io parameters in pydantic class
+        io_parameters: class, all io parameters in Pydantic class
         is_training: bool, whether the dataset is used for training or inference
-        is_full_inference: bool, whether the process is used for full inference
     Output:
-        dataset: class, TiledDataset
+        dataset: TiledDataset or TiledMaskedDataset
 
     """
-    data_tiled_client = from_uri(
-        io_parameters.data_tiled_uri, api_key=io_parameters.data_tiled_api_key
-    )
-    mask_tiled_client = None
-    if io_parameters.mask_tiled_uri:
-        mask_tiled_client = from_uri(
-            io_parameters.mask_tiled_uri, api_key=io_parameters.mask_tiled_api_key
+    try:
+        data_tiled_client = from_uri(
+            io_parameters.data_tiled_uri, api_key=io_parameters.data_tiled_api_key
         )
-    dataset = TiledDataset(
-        data_tiled_client=data_tiled_client,
-        mask_tiled_client=mask_tiled_client,
-        is_training=is_training,
-        is_full_inference=is_full_inference,
-    )
+    except Exception as e:
+        raise ValueError(f"Error initializing data tiled client: {e}")
+
+    if is_training and io_parameters.mask_tiled_uri:
+        try:
+            mask_tiled_client = from_uri(
+                io_parameters.mask_tiled_uri, api_key=io_parameters.mask_tiled_api_key
+            )
+            dataset = TiledMaskedDataset(data_tiled_client, mask_tiled_client)
+        except Exception as e:
+            raise ValueError(f"Error initializing mask tiled client: {e}")
+    else:
+        dataset = TiledDataset(data_tiled_client=data_tiled_client)
     return dataset

--- a/src/tiled_dataset.py
+++ b/src/tiled_dataset.py
@@ -9,7 +9,6 @@ class TiledDataset(torch.utils.data.Dataset):
         mask_tiled_client=None,
         is_training=False,
         is_full_inference=False,
-        transform=None,
     ):
         """
         Args:
@@ -19,7 +18,6 @@ class TiledDataset(torch.utils.data.Dataset):
             mask_tiled_api_key:  str,    Tiled API key for mask access
             is_training:         bool,   Whether this is a training instance
             is_full_inference:   bool,   Whether to perform full inference
-            transform:           callable, if not given return PIL image
 
         Return:
             ml_data:        tuple, (data_tensor, mask_tensor)
@@ -34,7 +32,6 @@ class TiledDataset(torch.utils.data.Dataset):
             self.mask_client = None
             self.mask_idx = None
 
-        self.transform = transform
         self.is_training = is_training
         self.is_full_inference = is_full_inference
 

--- a/src/train.py
+++ b/src/train.py
@@ -192,7 +192,7 @@ def train(args):
 def partial_inference(
     io_parameters, network_name, model_parameters, qlty_object, device, net
 ):
-    dataset = initialize_tiled_datasets(io_parameters, is_training=True)
+    dataset = initialize_tiled_datasets(io_parameters, is_training=False)
     torch.cuda.empty_cache()
     print(f"Partial Inference will be processed on: {device}")
     # Allocate Result space in Tiled

--- a/src/train.py
+++ b/src/train.py
@@ -10,13 +10,13 @@ from dlsia.core.train_scripts import Trainer
 from qlty.qlty2D import NCYXQuilt
 
 from network import build_network
+from tiled_dataset import initialize_tiled_datasets
 from utils import (
     allocate_array_space,
     construct_dataloaders,
     create_directory,
     ensure_parent_containers,
     find_device,
-    initialize_tiled_datasets,
     normalization,
     qlty_crop,
     segment_single_frame,

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,7 +17,6 @@ from parameters import (
     TUNet3PlusParameters,
     TUNetParameters,
 )
-from tiled_dataset import TiledDataset
 
 
 def validate_parameters(parameters):
@@ -55,36 +54,6 @@ def validate_parameters(parameters):
 
     print("Parameters loaded successfully.")
     return io_parameters, network, model_parameters
-
-
-def initialize_tiled_datasets(
-    io_parameters, is_training=False, is_full_inference=False
-):
-    """
-    This function takes tiled uris from the io_parameter class, build the client and construct TiledDataset.
-    Input:
-        io_parameters: class, all io parameters in pydantic class
-        is_training: bool, whether the dataset is used for training or inference
-        is_full_inference: bool, whether the process is used for full inference
-    Output:
-        dataset: class, TiledDataset
-
-    """
-    data_tiled_client = from_uri(
-        io_parameters.data_tiled_uri, api_key=io_parameters.data_tiled_api_key
-    )
-    mask_tiled_client = None
-    if io_parameters.mask_tiled_uri:
-        mask_tiled_client = from_uri(
-            io_parameters.mask_tiled_uri, api_key=io_parameters.mask_tiled_api_key
-        )
-    dataset = TiledDataset(
-        data_tiled_client=data_tiled_client,
-        mask_tiled_client=mask_tiled_client,
-        is_training=is_training,
-        is_full_inference=is_full_inference,
-    )
-    return dataset
 
 
 def normalization(image):

--- a/src/utils.py
+++ b/src/utils.py
@@ -84,7 +84,6 @@ def initialize_tiled_datasets(
         mask_tiled_client=mask_tiled_client,
         is_training=is_training,
         is_full_inference=is_full_inference,
-        using_qlty=False,
         transform=transforms.ToTensor(),
     )
     return dataset

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,6 @@ from qlty import cleanup
 from tiled.client import from_uri
 from tiled.structures.array import ArrayStructure
 from torch.utils.data import DataLoader, TensorDataset, random_split
-from torchvision import transforms
 
 from network import baggin_smsnet_ensemble, load_network
 from parameters import (
@@ -84,7 +83,6 @@ def initialize_tiled_datasets(
         mask_tiled_client=mask_tiled_client,
         is_training=is_training,
         is_full_inference=is_full_inference,
-        transform=transforms.ToTensor(),
     )
     return dataset
 


### PR DESCRIPTION
The previous iteration of `TiledDataset` used boolean parameters `is_full_segmentation` and `is_training`, as well as the setting attributes `mask_client` and `mask_idx` to `None` if no Tiled client with mask information was provided. 

This refactor converts `TiledDataset` to be equivalent to have the functionality previously used with `is_full_segmentation`. It is defined based on a Tiled client with data. Optionally a set of indices can be provided. This is useful for crafting data sets with any subsets of indices, but is also applied when mask information is given during training. 

`TiledMaskedDataset` is a subclass of `TiledDataset` that additionally requires a Tiled client with mask information. This client is expected to contain a list of integers in within `.metadata["mask_idx"]`, and contain actual mask data under the key `"mask"`. Presence of both is asserted. 

The parameter `is_training` is still in use for the function `initialize_tiled_datasets` (which has been moved from `utils.py` to `tiled_dataset.py`), but this may change in upcoming refactoring of `IOParameters`.

To summarize:
-`TiledDataset(data_client, mask_client=None, is_training=False, is_full_segmentation=True)` &rarr; `TiledDataset(data_client)`
-`TiledDataset(data_client, mask_client, is_training=False, is_full_segmentation=False)` &rarr; `TiledDataset(data_client, mask_client.metadata["mask_idx"])`
-`TiledDataset(data_client, mask_client, is_training=True, is_full_segmentation=False)` &rarr; `TiledMaskedDataset(data_client, mask_client)`

We may need to consider bringing back the `transform` parameter that used to convert to `torch.Tensor` and adapt downstream procedures to operate on tensors rather than `np.array`.