### PR TITLE
Add `job_name` to segmentation result metadata

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dvclive==3.44.0
 dlsia==0.3.1
 pydantic==2.6.3
 tiled[client]==0.1.0a114
+torch<=2.3.0

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -20,6 +20,7 @@ class IOParameters(BaseModel):
         default=None, description="tiled api key for segmentation results"
     )
     uid_save: str = Field(description="uid to save models, metrics and etc")
+    job_name: str = Field(description="segmentation job name")
     uid_retrieve: Optional[str] = Field(
         description="optional, uid to retrieve models for inference"
     )

--- a/src/segment.py
+++ b/src/segment.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
         seg_tiled_uri=io_parameters.seg_tiled_uri,
         seg_tiled_api_key=io_parameters.seg_tiled_api_key,
         uid=io_parameters.uid_save,
+        job_name=io_parameters.job_name,
         model=network,
         array_name="seg_result",
     )

--- a/src/train.py
+++ b/src/train.py
@@ -10,8 +10,8 @@ from dvclive import Live
 from tiled.client import from_uri
 from torchvision import transforms
 
-from .network import build_network
-from .parameters import (
+from network import build_network
+from parameters import (
     IOParameters,
     MSDNetParameters,
     SMSNetEnsembleParameters,
@@ -105,7 +105,7 @@ def train(args):
     weights = torch.tensor(weights, dtype=torch.float).to(device)
     criterion = criterion(weight=weights, ignore_index=-1, size_average=None)
 
-    use_dvclive = True
+    use_dvclive = False
     use_savedvcexp = False
 
     for idx, net in enumerate(networks):

--- a/src/train.py
+++ b/src/train.py
@@ -105,7 +105,7 @@ def train(args):
     weights = torch.tensor(weights, dtype=torch.float).to(device)
     criterion = criterion(weight=weights, ignore_index=-1, size_average=None)
 
-    use_dvclive = False
+    use_dvclive = True
     use_savedvcexp = False
 
     for idx, net in enumerate(networks):

--- a/src/utils.py
+++ b/src/utils.py
@@ -51,6 +51,7 @@ def allocate_array_space(
     seg_tiled_uri,
     seg_tiled_api_key,
     uid,
+    job_name,
     model,
     array_name,
 ):
@@ -59,10 +60,10 @@ def allocate_array_space(
 
     print(f"@@@@@@@@@@    last_container   {last_container.uri}")
     assert (
-        uid not in last_container.keys()
-    ), f"uid_save: {uid} already existed in Tiled Server"
+        job_name not in last_container.keys()
+    ), f"uid_save: {job_name} already existed in Tiled Server"
 
-    last_container = last_container.create_container(key=uid)
+    last_container = last_container.create_container(key=job_name)
 
     array_shape = (
         tiled_dataset.mask_client.shape
@@ -86,6 +87,7 @@ def allocate_array_space(
         "mask_uri": mask_uri,
         "mask_idx": tiled_dataset.mask_idx,
         "uid": uid,
+        "job_name": job_name,
         "model": model,
     }
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -60,10 +60,10 @@ def allocate_array_space(
 
     print(f"@@@@@@@@@@    last_container   {last_container.uri}")
     assert (
-        job_name not in last_container.keys()
-    ), f"uid_save: {job_name} already existed in Tiled Server"
+        uid not in last_container.keys()
+    ), f"uid_save: {uid} already existed in Tiled Server"
 
-    last_container = last_container.create_container(key=job_name)
+    last_container = last_container.create_container(key=uid)
 
     array_shape = (
         tiled_dataset.mask_client.shape


### PR DESCRIPTION
The `job_name` is defined within the segmentation front-end interface. This change connects the human-readable user-selected name within the front-end interface with the result, making the result searchable and displayable in other contexts aside from the segmentation interface. 

The PR also includes small fixes necessary during a recent deployment:
- pins `pytorch`, as model loading is otherwise yielding errors 
- temporarily disables `dvc` logging.

Companion PR to https://github.com/mlexchange/mlex_highres_segmentation/pull/193

Work by @taxe10.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209745598338309