### PR TITLE
Add mlflow wrapper for inference endpoint

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,7 +2,7 @@ name: Create and publish image
 
 on:
   push:
-    branches: ['main']
+    branches: ['hackathon']
     tags: ['v*']
 
 env:

--- a/mlex_dlsia/main.py
+++ b/mlex_dlsia/main.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
                 "Either mlflow_model or uid_retrieve must be provided for inference mode"
             )
 
-        net = load_network(model_name, network_type=model_parameters.network)
+        net = load_network(model_name)
         logging.info("Model loaded successfully for inference.")
 
         # Prepare dataset for inference

--- a/mlex_dlsia/mlflow_wrapper.py
+++ b/mlex_dlsia/mlflow_wrapper.py
@@ -58,15 +58,12 @@ class SegmentationWrapper(mlflow.pyfunc.PythonModel):
         if hasattr(model_input, "iloc"):
             row = model_input.iloc[0]
             data_tiled_uri = row.get("data_tiled_uri")
-            data_tiled_api_key = row.get("data_tiled_api_key")
         else:
             data_tiled_uri = model_input.get("data_tiled_uri")
-            data_tiled_api_key = model_input.get("data_tiled_api_key")
 
         # Define IOParameters for dataset initialization
         io_parameters = IOParameters(
             data_tiled_uri=data_tiled_uri,
-            data_tiled_api_key=data_tiled_api_key,
             uid_save=None,
             job_name=None,
             mlflow_model=None,

--- a/mlex_dlsia/mlflow_wrapper.py
+++ b/mlex_dlsia/mlflow_wrapper.py
@@ -5,18 +5,35 @@ from dlsia.core.networks.baggins import model_baggin
 
 from mlex_dlsia.dataset import initialize_tiled_datasets
 from mlex_dlsia.inference import _segment_single_frame, _segment_single_frame_ensemble
-from mlex_dlsia.parameters import IOParameters
+from mlex_dlsia.parameters import (
+    IOParameters,
+    MSDNetParameters,
+    SMSNetEnsembleParameters,
+    TUNet3PlusParameters,
+    TUNetParameters,
+)
 from mlex_dlsia.utils.dataloaders import construct_inference_dataloaders
+
+_NETWORK_PARAMS_MAP = {
+    "DLSIA MSDNet": MSDNetParameters,
+    "DLSIA TUNet": TUNetParameters,
+    "DLSIA TUNet3+": TUNet3PlusParameters,
+    "DLSIA SMSNetEnsemble": SMSNetEnsembleParameters,
+}
 
 
 class SegmentationWrapper(mlflow.pyfunc.PythonModel):
     def load_context(self, context):
         # Model params
         cfg = context.model_config
-        self.model_parameters = cfg
+        network_name = cfg.get("network")
+        params_cls = _NETWORK_PARAMS_MAP.get(network_name)
+        if params_cls is None:
+            raise ValueError(f"Unknown network type: {network_name!r}")
+        self.model_parameters = params_cls(**cfg)
 
         # Pick ensemble vs single-net inference function
-        self.network = cfg.get("network")
+        self.network = network_name
         is_ensemble = self.network == "DLSIA SMSNetEnsemble"
         self.final_layer = None if is_ensemble else torch.nn.Softmax(dim=1)
         self._segment_fn = (
@@ -37,9 +54,19 @@ class SegmentationWrapper(mlflow.pyfunc.PythonModel):
             self.net = nets[0]
 
     def predict(self, context, model_input):
+        # MLflow pyfunc converts dataframe_records payloads to a pandas DataFrame.
+        if hasattr(model_input, "iloc"):
+            row = model_input.iloc[0]
+            data_tiled_uri = row.get("data_tiled_uri")
+            data_tiled_api_key = row.get("data_tiled_api_key")
+        else:
+            data_tiled_uri = model_input.get("data_tiled_uri")
+            data_tiled_api_key = model_input.get("data_tiled_api_key")
+
         # Define IOParameters for dataset initialization
         io_parameters = IOParameters(
-            data_tiled_uri=model_input.get("data_tiled_uri"),
+            data_tiled_uri=data_tiled_uri,
+            data_tiled_api_key=data_tiled_api_key,
             uid_save=None,
             job_name=None,
             mlflow_model=None,
@@ -54,7 +81,7 @@ class SegmentationWrapper(mlflow.pyfunc.PythonModel):
             dataset.data_client.ndim >= 3
         ), f"Expected data_client to be at least 3D, got shape {dataset.data_client.shape}"
         results = np.empty(
-            (len(dataset), *dataset.data_client.shape[1:-1]), dtype=np.int8
+            (len(dataset), *dataset.data_client.shape[1:3]), dtype=np.int8
         )
 
         for idx in range(len(dataset)):

--- a/mlex_dlsia/mlflow_wrapper.py
+++ b/mlex_dlsia/mlflow_wrapper.py
@@ -1,0 +1,76 @@
+import mlflow
+import numpy as np
+import torch
+from dlsia.core.networks.baggins import model_baggin
+
+from mlex_dlsia.dataset import initialize_tiled_datasets
+from mlex_dlsia.inference import _segment_single_frame, _segment_single_frame_ensemble
+from mlex_dlsia.parameters import IOParameters
+from mlex_dlsia.utils.dataloaders import construct_inference_dataloaders
+
+
+class SegmentationWrapper(mlflow.pyfunc.PythonModel):
+    def load_context(self, context):
+        # Model params
+        cfg = context.model_config
+        self.model_parameters = cfg
+
+        # Pick ensemble vs single-net inference function
+        self.network = cfg.get("network")
+        is_ensemble = self.network == "DLSIA SMSNetEnsemble"
+        self.final_layer = None if is_ensemble else torch.nn.Softmax(dim=1)
+        self._segment_fn = (
+            _segment_single_frame_ensemble if is_ensemble else _segment_single_frame
+        )
+
+        # Load model(s) from artifacts and move to device
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        n_nets = cfg.get("n_nets", 1)
+        nets = [
+            torch.load(context.artifacts[f"net_{i+1}"], map_location=self.device)
+            for i in range(n_nets)
+        ]
+
+        if is_ensemble:
+            self.net = model_baggin(models=nets, model_type="classification")
+        else:
+            self.net = nets[0]
+
+    def predict(self, context, model_input):
+        # Define IOParameters for dataset initialization
+        io_parameters = IOParameters(
+            data_tiled_uri=model_input.get("data_tiled_uri"),
+            uid_save=None,
+            job_name=None,
+            mlflow_model=None,
+        )
+
+        # Initialize dataset for the input frames
+        dataset = initialize_tiled_datasets(
+            io_parameters, self.model_parameters, is_training=False
+        )
+
+        assert (
+            dataset.data_client.ndim >= 3
+        ), f"Expected data_client to be at least 3D, got shape {dataset.data_client.shape}"
+        results = np.empty(
+            (len(dataset), *dataset.data_client.shape[1:-1]), dtype=np.int8
+        )
+
+        for idx in range(len(dataset)):
+            inference_loader = construct_inference_dataloaders(
+                dataset[idx], self.model_parameters
+            )
+
+            prediction = self._segment_fn(
+                network=self.net,
+                dataloader=inference_loader,
+                final_layer=self.final_layer,
+                device=self.device,
+            )
+            stitched_prediction, _ = dataset.qlty_object.stitch(prediction)
+            results[idx] = (
+                torch.argmax(stitched_prediction, dim=1).numpy().astype(np.int8)
+            )
+
+        return results

--- a/mlex_dlsia/network.py
+++ b/mlex_dlsia/network.py
@@ -91,20 +91,44 @@ def load_network(model_name):
     model_version = client.get_latest_versions(model_name)[0]
     run_id = model_version.run_id
 
-    # Download artifacts locally
-    artifact_dir = mlflow.artifacts.download_artifacts(
-        run_id=run_id, artifact_path="model"
-    )
-
-    cfg = model_version.tags  # or load MLmodel config if needed
-    n_nets = int(cfg.get("n_nets", 1))
+    cfg = model_version.tags
     is_ensemble = cfg.get("network") == "DLSIA SMSNetEnsemble"
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    nets = [
-        torch.load(os.path.join(artifact_dir, f"net_{i+1}.pt"), map_location=device)
-        for i in range(n_nets)
+    # Download artifacts directly from MLflow under the pyfunc model artifacts dir.
+    # Newer runs store nets as model/artifacts/net_*.pt.
+    artifact_infos = client.list_artifacts(run_id, path="model/artifacts")
+    net_artifact_paths = sorted(
+        [
+            info.path
+            for info in artifact_infos
+            if not info.is_dir and os.path.basename(info.path).startswith("net_")
+        ]
+    )
+
+    if not net_artifact_paths:
+        # Backward-compatible fallback for older layout: model/net_*.pt
+        artifact_infos = client.list_artifacts(run_id, path="model")
+        net_artifact_paths = sorted(
+            [
+                info.path
+                for info in artifact_infos
+                if not info.is_dir and os.path.basename(info.path).startswith("net_")
+            ]
+        )
+
+    n_nets = int(cfg.get("n_nets", len(net_artifact_paths) or 1))
+    if len(net_artifact_paths) < n_nets:
+        raise FileNotFoundError(
+            f"Expected {n_nets} model artifacts but found {len(net_artifact_paths)} for run {run_id}."
+        )
+
+    local_net_paths = [
+        mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=path)
+        for path in net_artifact_paths[:n_nets]
     ]
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    nets = [torch.load(path, map_location=device) for path in local_net_paths]
 
     if is_ensemble:
         return model_baggin(models=nets, model_type="classification")

--- a/mlex_dlsia/network.py
+++ b/mlex_dlsia/network.py
@@ -1,7 +1,9 @@
 import logging
+import os
 
 import mlflow
 import numpy as np
+import torch
 import torch.nn as nn
 from dlsia.core import helpers
 from dlsia.core.networks import msdnet, smsnet, tunet, tunet3plus
@@ -84,26 +86,30 @@ def build_network(
     return network
 
 
-def load_network(model_name, network_type=None):
-    """
-    This function loads pre-trained DLSIA network. Support both single network and ensembles.
-    Input:
-        model_name: str, name of the model in MLflow registry
-        network_type: str, optional, type of network (e.g., "DLSIA SMSNetEnsemble")
-    Output:
-        net: loaded pre-trained network
-    """
-    # Handle ensemble vs single model
-    if network_type == "DLSIA SMSNetEnsemble":
-        logging.info(f"Loading ensemble models from MLflow registry: {model_name}")
-        net = baggin_smsnet_ensemble(mlflow_model_name=model_name)
-    else:
-        # Single model case
-        logging.info(f"Loading latest model from MLflow registry: {model_name}")
-        net = mlflow.pytorch.load_model(f"models:/{model_name}/latest")
-        logging.info(f"Model loaded from MLflow registry: models:/{model_name}/latest")
+def load_network(model_name):
+    client = mlflow.MlflowClient()
+    model_version = client.get_latest_versions(model_name)[0]
+    run_id = model_version.run_id
 
-    return net
+    # Download artifacts locally
+    artifact_dir = mlflow.artifacts.download_artifacts(
+        run_id=run_id, artifact_path="model"
+    )
+
+    cfg = model_version.tags  # or load MLmodel config if needed
+    n_nets = int(cfg.get("n_nets", 1))
+    is_ensemble = cfg.get("network") == "DLSIA SMSNetEnsemble"
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    nets = [
+        torch.load(os.path.join(artifact_dir, f"net_{i+1}.pt"), map_location=device)
+        for i in range(n_nets)
+    ]
+
+    if is_ensemble:
+        return model_baggin(models=nets, model_type="classification")
+    else:
+        return nets[0]
 
 
 # ============================MSDNet==================================#

--- a/mlex_dlsia/parameters.py
+++ b/mlex_dlsia/parameters.py
@@ -21,8 +21,10 @@ class IOParameters(BaseModel):
     seg_tiled_api_key: Optional[str] = Field(
         default=None, description="tiled api key for segmentation results"
     )
-    uid_save: str = Field(description="uid to save models, metrics and etc")
-    job_name: str = Field(description="segmentation job name")
+    uid_save: Optional[str] = Field(
+        default=None, description="uid to save models, metrics and etc"
+    )
+    job_name: Optional[str] = Field(default=None, description="segmentation job name")
     uid_retrieve: Optional[str] = Field(
         default=None, description="optional, uid to retrieve models for inference"
     )

--- a/mlex_dlsia/parameters.py
+++ b/mlex_dlsia/parameters.py
@@ -6,7 +6,9 @@ from pydantic import BaseModel, Field
 # ===========================================I/O Related Parameters===========================================#
 class IOParameters(BaseModel):
     data_tiled_uri: str = Field(description="tiled uri for image data")
-    data_tiled_api_key: str = Field(description="tiled api key for data client")
+    data_tiled_api_key: Optional[str] = Field(
+        default=None, description="tiled api key for data client"
+    )
     mask_tiled_uri: Optional[str] = Field(
         default=None, description="tiled uri for masks"
     )
@@ -22,7 +24,7 @@ class IOParameters(BaseModel):
     uid_save: str = Field(description="uid to save models, metrics and etc")
     job_name: str = Field(description="segmentation job name")
     uid_retrieve: Optional[str] = Field(
-        description="optional, uid to retrieve models for inference"
+        default=None, description="optional, uid to retrieve models for inference"
     )
     models_dir: Optional[str] = Field(
         default=None, description="directory to save model results"

--- a/mlex_dlsia/train.py
+++ b/mlex_dlsia/train.py
@@ -8,6 +8,8 @@ import torch.optim as optim
 from dlsia.core.networks.baggins import model_baggin
 from dlsia.core.train_scripts import Trainer
 
+from mlex_dlsia.mlflow_wrapper import SegmentationWrapper
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
@@ -23,9 +25,7 @@ def _build_criterion(model_parameters, device, ignore_index=-1):
     Output:
         criterion:
     """
-    # Define criterion and optimizer
     criterion = getattr(nn, model_parameters.criterion)
-    # Convert the string to a list of floats
     weights = [float(x) for x in model_parameters.weights.strip("[]").split(",")]
     weights = torch.tensor(weights, dtype=torch.float).to(device)
     criterion = criterion(weight=weights, ignore_index=ignore_index)
@@ -85,6 +85,7 @@ def run_train(
 
         network_name = model_parameters.network
         trained_nets = []
+        dvclive_savepath = f"{model_dir}/dvc_metrics"
 
         for idx, net in enumerate(networks):
             logger.info(f"{network_name}: {idx+1}/{len(networks)}")
@@ -95,7 +96,6 @@ def run_train(
             if use_dvclive:
                 from dvclive import Live
 
-                dvclive_savepath = f"{model_dir}/dvc_metrics"
                 dvclive = Live(
                     dvclive_savepath, report="html", save_dvc_exp=use_savedvcexp
                 )
@@ -118,15 +118,8 @@ def run_train(
                 use_amp=False,
                 clip_value=None,
             )
-            net, _ = trainer.train_segmentation()  # training happens here
-
+            net, _ = trainer.train_segmentation()
             trained_nets.append(net)
-
-            # Log model to MLflow
-            mlflow.pytorch.log_model(
-                net, f"model_{idx+1}", registered_model_name=io_parameters.uid_save
-            )
-            logging.info(f"Model logged to MLflow with name: {io_parameters.uid_save}")
 
             # Log DVC metrics to MLflow
             if use_dvclive and os.path.exists(dvclive_savepath):
@@ -137,6 +130,30 @@ def run_train(
             torch.cuda.empty_cache()
 
         logger.info(f"{network_name} trained successfully.")
+
+        # Save all trained nets and build artifact paths
+        artifact_paths = {}
+        for idx, net in enumerate(trained_nets):
+            path = os.path.join(model_dir, f"net_{idx+1}.pt")
+            torch.save(net, path)
+            artifact_paths[f"net_{idx+1}"] = path
+
+        # Log model to MLflow once after all nets are trained
+        mlflow.pyfunc.log_model(
+            artifact_path="model",
+            python_model=SegmentationWrapper(),
+            artifacts=artifact_paths,
+            model_config={
+                "network": model_parameters.network,
+                "num_classes": model_parameters.num_classes,
+                "qlty_window": model_parameters.qlty_window,
+                "qlty_step": model_parameters.qlty_step,
+                "qlty_border": model_parameters.qlty_border,
+                "n_nets": len(trained_nets),
+            },
+            registered_model_name=io_parameters.uid_save,
+        )
+        logging.info(f"Model logged to MLflow with name: {io_parameters.uid_save}")
 
         # Create final model (ensemble or single)
         if model_parameters.network == "DLSIA SMSNetEnsemble":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "qlty==0.2.0",
   "dvclive==3.44.0",
   "dlsia==0.3.4",
-  "pydantic>=1.10.15",
+  "pydantic>=2.8",
   "tiled[client]==0.2.0",
   "mlflow==2.22.0",
   "torch==2.2.2"


### PR DESCRIPTION
## Summary
Add MLflow-backed inference packaging so trained segmentation models can be served through an inference endpoint.

## What Changed
- Added a new `SegmentationWrapper` MLflow `pyfunc` model for segmentation inference.
- Updated training so all trained nets are saved as artifacts and logged once as a single MLflow model, instead of logging each network independently.
- Added wrapper support for both single-network segmentation models and `DLSIA SMSNetEnsemble` inference via bagged models.
- Included model config needed for inference-time reconstruction, including QLTY stitching parameters and ensemble size.
- Relaxed some `IOParameters` fields to be optional so inference-only usage does not require training-only values.
- Updated the Pydantic dependency to v2-compatible constraints.

## Why
This makes the training output directly deployable through MLflow model serving and supports inference endpoint integration without requiring custom post-training packaging.

## Notes
- The wrapper builds tiled datasets from request input, runs frame-wise inference, stitches predictions, and returns class masks as NumPy arrays.
- Existing training behavior is preserved — the main change is how models are packaged and registered in MLflow.